### PR TITLE
Front end validation and updates

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="script-src">
+            <values>
+                <value id="cardknox-ifields-script" type="host">https://cdn.cardknox.com/ifields/2.6.2006.0102/ifields.min.js</value>
+            </values>
+        </policy>
+        <policy id="frame-src">
+            <values>
+                <value id="cardknox-ifields" type="host">https://cdn.cardknox.com/</value>
+            </values>
+        </policy>  
+    </policies>
+</csp_whitelist>

--- a/view/adminhtml/templates/form/cc.phtml
+++ b/view/adminhtml/templates/form/cc.phtml
@@ -25,7 +25,7 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
         </label>
         <div class="admin__field-control">
             <iframe data-ifields-id="card-number" data-ifields-placeholder="Card Number"
-                    src="https://cdn.cardknox.com/ifields/2.5.1905.0801/ifield.htm" frameBorder="0" width="100%"
+                    src="https://cdn.cardknox.com/ifields/2.6.2006.0102/ifield.htm" frameBorder="0" width="100%"
                     height="33"></iframe>
             <input data-ifields-id="card-number-token" name="payment[xCardNum]" type="hidden"/>
         </div>
@@ -64,7 +64,7 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
             </label>
             <div class="admin__field-control">
                 <iframe data-ifields-id="cvv" data-ifields-placeholder="CVV"
-                        src="https://cdn.cardknox.com/ifields/2.5.1905.0801/ifield.htm" frameBorder="0" width="100%"
+                        src="https://cdn.cardknox.com/ifields/2.6.2006.0102/ifield.htm" frameBorder="0" width="100%"
                         height="33"></iframe>
                 <input data-ifields-id="cvv-token" name="payment[xCVV]" type="hidden"/>
                 <label id="ifieldsError" data-ifields-id="card-data-error"></label>

--- a/view/adminhtml/web/cardknox.js
+++ b/view/adminhtml/web/cardknox.js
@@ -84,6 +84,30 @@ define([
             self.initCardknox();
         },
 
+        defaultStyle: {
+            border: '1px solid #adadad',
+            'font-size': '14px',
+            padding: '3px',
+            width: '145px',
+            height: '25px'
+        },
+
+        validStyle: {
+            border: '2px solid green',
+            'font-size': '14px',
+            padding: '3px',
+            width: '145px',
+            height: '25px'
+        },
+
+        invalidStyle: {
+            border: '2px solid red',
+            'font-size': '14px',
+            padding: '3px',
+            width: '145px',
+            height: '25px'
+        },
+
         /**
          * Setup Cardknox SDK
          */
@@ -93,15 +117,26 @@ define([
                 //setAccount(this.saveOnlyKey, "Magento2", "0.1.2");
                 enableLogging();
                 setAccount(this.tokenKey, "Magento2", "0.1.2");
-                var style = {
-                    border: '1px solid #adadad',
-                    'font-size': '14px',
-                    padding: '3px',
-                    width: '145px',
-                    height: '25px'
-                };
-                setIfieldStyle('card-number', style);
-                setIfieldStyle('cvv', style);
+                enableAutoFormatting();
+                setIfieldStyle('card-number', self.defaultStyle);
+                setIfieldStyle('cvv', self.defaultStyle);
+                addIfieldCallback('input', function(data) {
+
+                    if (data.ifieldValueChanged) {
+                        setIfieldStyle('card-number', data.cardNumberFormattedLength <= 0 ? self.defaultStyle : data.cardNumberIsValid ? self.validStyle : self.invalidStyle);
+                        if (data.lastIfieldChanged === 'cvv'){
+                            setIfieldStyle('cvv', data.issuer === 'unknown' || data.cvvLength <= 0 ? self.defaultStyle : data.cvvIsValid ? self.validStyle : self.invalidStyle);
+                        } else if (data.lastIfieldChanged === 'card-number') {
+                            if (data.issuer === 'unknown' || data.cvvLength <= 0) {
+                                setIfieldStyle('cvv', self.defaultStyle);
+                            } else if (data.issuer === 'amex'){
+                                setIfieldStyle('cvv', data.cvvLength === 4 ? self.validStyle : self.invalidStyle);
+                            } else {
+                                setIfieldStyle('cvv', data.cvvLength === 3 ? self.validStyle : self.invalidStyle);
+                            }
+                        }
+                    }
+                });
             } catch (e) {
                 $('body').trigger('processStop');
                 self.error(e.message);

--- a/view/base/requirejs-config.js
+++ b/view/base/requirejs-config.js
@@ -4,6 +4,6 @@
  */
 var config = {
     paths: {
-        ifields: 'https://cdn.cardknox.com/ifields/2.5.1905.0801/ifields.min'
+        ifields: 'https://cdn.cardknox.com/ifields/2.6.2006.0102/ifields.min'
     }
 };

--- a/view/frontend/web/template/payment/cardknox-form.html
+++ b/view/frontend/web/template/payment/cardknox-form.html
@@ -33,10 +33,12 @@
                     <label data-bind="attr: {for: getCode() + '_number'}" class="label">
                         <span><!-- ko i18n: 'Card  Number'--><!-- /ko --></span>
                     </label>
-                    <iframe data-ifields-id="card-number" data-ifields-placeholder="Card Number"
-                            src="https://cdn.cardknox.com/ifields/2.5.1905.0801/ifield.htm" frameBorder="0" width="100%"
-                            height="33"></iframe>
-                    <input data-ifields-id="card-number-token" name="xCardNum" type="hidden"/>
+                    <div class="control">
+                        <iframe data-ifields-id="card-number" data-ifields-placeholder="Card Number"
+                                src="https://cdn.cardknox.com/ifields/2.6.2006.0102/ifield.htm" frameBorder="0"
+                                height="35"></iframe>
+                        <input data-ifields-id="card-number-token" name="xCardNum" type="hidden"/>
+                    </div>
                 </div>
                 <div class="field date required" data-bind="attr: {id: getCode() + '_cc_type_exp_div'}">
                     <label data-bind="attr: {for: getCode() + '_expiration'}" class="label">
@@ -79,14 +81,28 @@
                     <label data-bind="attr: {for: getCode() + '_cvv'}" class="label">    
                         <span><!-- ko i18n: 'Card Verification Number'--><!-- /ko --></span>
                     </label>
-                    <iframe data-ifields-id="cvv" data-ifields-placeholder="CVV"
-                            src="https://cdn.cardknox.com/ifields/2.5.1905.0801/ifield.htm" frameBorder="0" width="100%"
-                            height="33"></iframe>
+                    <div class="control _with-tooltip">
+                        <iframe data-ifields-id="cvv" data-ifields-placeholder="CVV"
+                        src="https://cdn.cardknox.com/ifields/2.6.2006.0102/ifield.htm" frameBorder="0"
+                        height="35"></iframe>
+                        <div class="field-tooltip toggle">
+                            <span class="field-tooltip-action action-cvv"
+                                    tabindex="0"
+                                    data-toggle="dropdown"
+                                    data-bind="attr: {title: $t('What is this?')}, mageInit: {'dropdown':{'activeClass': '_active'}}">
+                                <span><!-- ko i18n: 'What is this?'--><!-- /ko --></span>
+                            </span>
+                            <div class="field-tooltip-content"
+                                    data-target="dropdown"
+                                    data-bind="html: getCvvImageHtml()"></div>
+                        </div>
+                    </div>      
                     <input data-ifields-id="cvv-token" name="xCVV" type="hidden"/>
                     <label data-ifields-id="card-data-error" id="ifieldsError"></label>
                 </div>
-                 <!--ko if: (isVaultEnabled())-->
-                 <div class="field choice">
+                <label id="transaction-status" class="label"></label>
+                <!-- ko if: (isVaultEnabled()) -->
+                <div class="field choice">
                     <input type="checkbox"
                         name="vault[is_enabled]"
                         class="checkbox"


### PR DESCRIPTION
Fix CSP warning.
Use Ifields card formatting and validation.
Enforce validation on the frontend (admin will only highlight in red for now).
Show front end validation errors near the credit card fields with focus (don't use the default Magento messaging to avoid missing the error message).
Update to latest stable version of IFields (2.6.2006.0102).
Add CVV tooltip to the front end.