### PR TITLE
Fix Allow duplicate transaction checkbox not clickable

### DIFF
--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,5 +1,6 @@
 1.0.20
 - Update the plugin to the latest version of iFields 2.15.2401.3101
+- Fix Allow duplicate transaction checkbox not clickable
 
 1.0.19
 - Update the plugin to the latest version of iFields 2.15.2309.2601

--- a/view/frontend/web/template/payment/cardknox-form.html
+++ b/view/frontend/web/template/payment/cardknox-form.html
@@ -110,16 +110,14 @@
                 </div>
                 <!-- /ko -->
                 <div class="ck-allow-duplicate-transaction" data-bind="visible: isAllowDuplicateTransaction">
-                    <div class="field choice">
-                        <input type="checkbox"
-                            name="is_allow_duplicate_transaction"
-                            class="checkbox"
-                            id="is_allow_duplicate_transaction_cc"
-                            >
-                        <label class="label" >
-                            <span><!-- ko i18n: 'Allow Duplicate Transaction'--><!-- /ko --></span>
-                        </label>
-                    </div>
+                    <input type="checkbox"
+                        name="is_allow_duplicate_transaction"
+                        class="checkbox"
+                        id="is_allow_duplicate_transaction_cc"
+                        >
+                    <label class="label" for="is_allow_duplicate_transaction_cc">
+                        <span><!-- ko i18n: 'Allow Duplicate Transaction'--><!-- /ko --></span>
+                    </label>
                 </div>
                 <!-- ko if: (isEnabledReCaptcha())-->
                     <div class="g-recaptcha" id="cardknox_recaptcha"></div>


### PR DESCRIPTION
On the Credit Card payment method, **Allow Duplicate Transaction** is not clickable.

**Screenshot**: https://i.imgur.com/5J89TR5.png