### PR TITLE
Fix retrieving correct client ip address

### DIFF
--- a/Gateway/Request/ApplePayBaseRequest.php
+++ b/Gateway/Request/ApplePayBaseRequest.php
@@ -11,6 +11,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
+use CardknoxDevelopment\Cardknox\Helper\Data;
 
 class ApplePayBaseRequest implements BuilderInterface
 {
@@ -25,15 +26,23 @@ class ApplePayBaseRequest implements BuilderInterface
     private $productMetadata;
 
     /**
+     * @var Data
+     */
+    private $helper;
+
+    /**
      * @param ProductMetadataInterface $productMetadata
      * @param Config $config
+     * @param Data $helper
      */
     public function __construct(
         ProductMetadataInterface $productMetadata,
-        Config $config
+        Config $config,
+        Data $helper
     ) {
         $this->productMetadata = $productMetadata;
         $this->config = $config;
+        $this->helper = $helper;
     }
 
     /**
@@ -55,7 +64,7 @@ class ApplePayBaseRequest implements BuilderInterface
 
         $order = $paymentDO->getOrder();
         $xSoftwareName = 'Magento ' . $this->productMetadata->getEdition() . " ". $this->productMetadata->getVersion();
-
+        $ipAddress = $this->helper->getIpAddress();
         return [
             'xVersion' => '4.5.8',
             'xSoftwareName' => $xSoftwareName,
@@ -65,7 +74,7 @@ class ApplePayBaseRequest implements BuilderInterface
                 $order->getStoreId()
             ),
             'xDigitalWalletType' => 'applepay',
-            'xIP' => $order->getRemoteIp(),
+            'xIP' => $ipAddress ? $ipAddress : $order->getRemoteIp(),
         ];
     }
 }

--- a/Gateway/Request/BaseRequest.php
+++ b/Gateway/Request/BaseRequest.php
@@ -66,12 +66,6 @@ class BaseRequest implements BuilderInterface
         $version = $this->productMetadata->getVersion();
         $ipAddress = $this->helper->getIpAddress();
 
-        $writer = new \Zend_Log_Writer_Stream(BP . '/var/log/ipAddress.log');
-        $logger = new \Zend_Log();
-        $logger->addWriter($writer);
-        $logger->info("ipAddress ". $ipAddress);
-        $logger->info("orderRemoteIp ". $order->getRemoteIp());
-
         return [
             'xVersion' => '4.5.8',
             'xSoftwareName' => 'Magento ' . $edition . " ". $version,

--- a/Gateway/Request/GooglePayBaseRequest.php
+++ b/Gateway/Request/GooglePayBaseRequest.php
@@ -11,6 +11,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
+use CardknoxDevelopment\Cardknox\Helper\Data;
 
 class GooglePayBaseRequest implements BuilderInterface
 {
@@ -25,15 +26,23 @@ class GooglePayBaseRequest implements BuilderInterface
     private $productMetadata;
 
     /**
+     * @var Data
+     */
+    private $helper;
+
+    /**
      * @param ProductMetadataInterface $productMetadata
      * @param Config $config
+     * @param Data $helper
      */
     public function __construct(
         ProductMetadataInterface $productMetadata,
-        Config $config
+        Config $config,
+        Data $helper
     ) {
         $this->productMetadata = $productMetadata;
         $this->config = $config;
+        $this->helper = $helper;
     }
 
     /**
@@ -55,7 +64,7 @@ class GooglePayBaseRequest implements BuilderInterface
 
         $order = $paymentDO->getOrder();
         $xSoftwareName = 'Magento ' . $this->productMetadata->getEdition() . " ". $this->productMetadata->getVersion();
-
+        $ipAddress = $this->helper->getIpAddress();
         return [
             'xVersion' => '4.5.8',
             'xSoftwareName' => $xSoftwareName,
@@ -65,7 +74,7 @@ class GooglePayBaseRequest implements BuilderInterface
                 $order->getStoreId()
             ),
             'xDigitalWalletType' => 'GooglePay',
-            'xIP' => $order->getRemoteIp(),
+            'xIP' => $ipAddress ? $ipAddress : $order->getRemoteIp(),
         ];
     }
 }

--- a/Gateway/Request/GooglePayBaseRequest.php
+++ b/Gateway/Request/GooglePayBaseRequest.php
@@ -11,7 +11,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Magento\Framework\App\ProductMetadataInterface;
 use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
-use CardknoxDevelopment\Cardknox\Helper\Data;
+use CardknoxDevelopment\Cardknox\Helper\Data as Helper;
 
 class GooglePayBaseRequest implements BuilderInterface
 {
@@ -26,23 +26,23 @@ class GooglePayBaseRequest implements BuilderInterface
     private $productMetadata;
 
     /**
-     * @var Data
+     * @var Helper
      */
-    private $helper;
+    private $dataHelper;
 
     /**
      * @param ProductMetadataInterface $productMetadata
      * @param Config $config
-     * @param Data $helper
+     * @param Data $dataHelper
      */
     public function __construct(
         ProductMetadataInterface $productMetadata,
         Config $config,
-        Data $helper
+        Helper $dataHelper
     ) {
         $this->productMetadata = $productMetadata;
         $this->config = $config;
-        $this->helper = $helper;
+        $this->dataHelper = $dataHelper;
     }
 
     /**
@@ -64,7 +64,7 @@ class GooglePayBaseRequest implements BuilderInterface
 
         $order = $paymentDO->getOrder();
         $xSoftwareName = 'Magento ' . $this->productMetadata->getEdition() . " ". $this->productMetadata->getVersion();
-        $ipAddress = $this->helper->getIpAddress();
+        $_ipAddress = $this->dataHelper->getIpAddress();
         return [
             'xVersion' => '4.5.8',
             'xSoftwareName' => $xSoftwareName,
@@ -74,7 +74,7 @@ class GooglePayBaseRequest implements BuilderInterface
                 $order->getStoreId()
             ),
             'xDigitalWalletType' => 'GooglePay',
-            'xIP' => $ipAddress ? $ipAddress : $order->getRemoteIp(),
+            'xIP' => $_ipAddress ? $_ipAddress : $order->getRemoteIp(),
         ];
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -56,4 +56,26 @@ class Data extends AbstractHelper
             \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE
         );
     }
+    /**
+     * Get Client IP address
+     *
+     * @return string|null
+     */
+    public function getIpAddress()
+    {
+        //phpcs:disable
+        $ipAddress = null;
+        // if user from the share internet
+        if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
+            $ipAddress = $_SERVER['HTTP_CLIENT_IP'];
+        } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+            //if user is from the proxy
+            $ipAddress = $_SERVER['HTTP_X_FORWARDED_FOR'];
+        } else {
+            //if user is from the remote address
+            $ipAddress = $_SERVER['REMOTE_ADDR'];
+        }
+        //phpcs:enable
+        return $ipAddress;
+    }
 }

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,5 +1,6 @@
 1.0.21
 - Add ApplePay to cart page
+- Fix retrieving the Client's IP Address
 
 1.0.20
 - Update the plugin to the latest version of iFields 2.15.2401.3101


### PR DESCRIPTION
Sometimes, the user always gets a 127.0.0.1 client IP address in the API request.
To figure out this issue, we get the IP address from below 4 ways:
1. if a user is from the shared internet
2. If a user is from the proxy
3. If a user is from the remote address
4. If the above 3 ways, if the IP address is not getting then, it will get from the magento order Remote IP address.
