### PR TITLE
Fix: Passing wrong amount to cardknox API request for GooglePay & ApplePay

### DIFF
--- a/Gateway/Request/ApplePayAuthorizationRequest.php
+++ b/Gateway/Request/ApplePayAuthorizationRequest.php
@@ -60,7 +60,7 @@ class ApplePayAuthorizationRequest implements BuilderInterface
         $paymentDO = $buildSubject['payment'];
         $order = $paymentDO->getOrder();
         $payment = $paymentDO->getPayment();
-        $amount = $this->helper->formatPrice($payment->getAdditionalInformation("xAmount"));
+        $amount = $this->helper->formatPrice($buildSubject['amount']);
         $isAllowDuplicateTransactionApAuth = $payment->getAdditionalInformation("isAllowDuplicateTransaction");
         
         return [

--- a/Gateway/Request/ApplePayBaseRequest.php
+++ b/Gateway/Request/ApplePayBaseRequest.php
@@ -68,7 +68,7 @@ class ApplePayBaseRequest implements BuilderInterface
         return [
             'xVersion' => '4.5.8',
             'xSoftwareName' => $xSoftwareName,
-            'xSoftwareVersion' => '1.0.23',
+            'xSoftwareVersion' => '1.0.24',
             'xKey' => $this->config->getValue(
                 'cardknox_transaction_key',
                 $order->getStoreId()

--- a/Gateway/Request/ApplePayCaptureRequest.php
+++ b/Gateway/Request/ApplePayCaptureRequest.php
@@ -62,7 +62,7 @@ class ApplePayCaptureRequest implements BuilderInterface
         $order = $paymentDO->getOrder();
         $payment = $paymentDO->getPayment();
 
-        $amount = $this->helper->formatPrice($payment->getAdditionalInformation("xAmount"));
+        $amount = $this->helper->formatPrice($buildSubject['amount']);
 
         if (!$payment instanceof OrderPaymentInterface) {
             throw new \LogicException('Order payment should be provided.');

--- a/Gateway/Request/BaseRequest.php
+++ b/Gateway/Request/BaseRequest.php
@@ -69,7 +69,7 @@ class BaseRequest implements BuilderInterface
         return [
             'xVersion' => '4.5.8',
             'xSoftwareName' => 'Magento ' . $edition . " ". $version,
-            'xSoftwareVersion' => '1.0.23',
+            'xSoftwareVersion' => '1.0.24',
             'xKey' => $this->config->getValue(
                 'cardknox_transaction_key',
                 $order->getStoreId()

--- a/Gateway/Request/GooglePayAuthorizationRequest.php
+++ b/Gateway/Request/GooglePayAuthorizationRequest.php
@@ -60,7 +60,7 @@ class GooglePayAuthorizationRequest implements BuilderInterface
         $paymentDO = $buildSubject['payment'];
         $order = $paymentDO->getOrder();
         $payment = $paymentDO->getPayment();
-        $amount = $this->helper->formatPrice($payment->getAdditionalInformation("xAmount"));
+        $amount = $this->helper->formatPrice($buildSubject['amount']);
         // phpcs:disable
         $gPayPaymentAction = $payment->getAdditionalInformation("xPaymentAction") ? $payment->getAdditionalInformation("xPaymentAction") : $this->config->getGPayPaymentAction();
         $isGPaySplitCaptureEnabled = $payment->getAdditionalInformation("isSplitCapture") ? $payment->getAdditionalInformation("isSplitCapture") : $this->helper->isGPaySplitCaptureEnabled();

--- a/Gateway/Request/GooglePayBaseRequest.php
+++ b/Gateway/Request/GooglePayBaseRequest.php
@@ -68,7 +68,7 @@ class GooglePayBaseRequest implements BuilderInterface
         return [
             'xVersion' => '4.5.8',
             'xSoftwareName' => $xSoftwareName,
-            'xSoftwareVersion' => '1.0.23',
+            'xSoftwareVersion' => '1.0.24',
             'xKey' => $this->config->getValue(
                 'cardknox_transaction_key',
                 $order->getStoreId()

--- a/Gateway/Request/GooglePayCaptureRequest.php
+++ b/Gateway/Request/GooglePayCaptureRequest.php
@@ -62,7 +62,7 @@ class GooglePayCaptureRequest implements BuilderInterface
         $order = $paymentDO->getOrder();
         $payment = $paymentDO->getPayment();
 
-        $amount = $this->helper->formatPrice($payment->getAdditionalInformation("xAmount"));
+        $amount = $this->helper->formatPrice($buildSubject['amount']);
         
         if (!$payment instanceof OrderPaymentInterface) {
             throw new \LogicException('Order payment should be provided.');

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "cardknox/cardknox",
     "description": "Cardknox integration for Magento 2",
     "type": "magento2-module",
-    "version": "1.0.23",
+    "version": "1.0.24",
     "license": [
         "GPL-3.0"
     ],

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,6 @@
+1.0.24
+- Fix: Passing wrong amount to cardknox API request for GooglePay & ApplePay
+
 1.0.23
 - feat: add shipping methods to GooglePay & ApplePay popup on cart page
 - feat: add tax & discount to summary in GooglePay & ApplePay Popup on cart page

--- a/view/adminhtml/web/cardknox.js
+++ b/view/adminhtml/web/cardknox.js
@@ -116,7 +116,7 @@ define([
             try {
                 //setAccount(this.saveOnlyKey, "Magento2", "0.1.2");
                 enableLogging();
-                setAccount(this.tokenKey, "Magento2", "1.0.23");
+                setAccount(this.tokenKey, "Magento2", "1.0.24");
                 enableAutoFormatting();
                 setIfieldStyle('card-number', self.defaultStyle);
                 setIfieldStyle('cvv', self.defaultStyle);

--- a/view/frontend/web/js/view/payment/method-renderer/cardknox-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cardknox-method.js
@@ -162,7 +162,7 @@ define(
                  * [Required]
                  * Set your account data using setAccount(ifieldKey, yourSoftwareName, yourSoftwareVersion).
                  */
-                setAccount(window.checkoutConfig.payment.cardknox.tokenKey, "Magento2", "1.0.23");
+                setAccount(window.checkoutConfig.payment.cardknox.tokenKey, "Magento2", "1.0.24");
 
                 /*
                  * [Optional]


### PR DESCRIPTION
Sometimes, when a user places an order by GooglePay or ApplePay, cardknox charges the wrong amount.
See more details:

**Magento Order Total** = $1,180.32 &  **Cardknox charges** = $1,183.15 for payment.
- Magento screenshot (URL: https://d.pr/i/211VuD)
- Cardknox charges (URL: https://www.awesomescreenshot.com/image/48471227?key=7fff893e673a9457ea22903f7b9eaeaf)

