### PR TITLE
Add release note for cardknox magento plugin version 1.0.27

### DIFF
--- a/Gateway/Request/ApplePayBaseRequest.php
+++ b/Gateway/Request/ApplePayBaseRequest.php
@@ -68,7 +68,7 @@ class ApplePayBaseRequest implements BuilderInterface
         return [
             'xVersion' => '4.5.8',
             'xSoftwareName' => $xSoftwareName,
-            'xSoftwareVersion' => '1.0.26',
+            'xSoftwareVersion' => '1.0.27',
             'xKey' => $this->config->getValue(
                 'cardknox_transaction_key',
                 $order->getStoreId()

--- a/Gateway/Request/BaseRequest.php
+++ b/Gateway/Request/BaseRequest.php
@@ -69,7 +69,7 @@ class BaseRequest implements BuilderInterface
         return [
             'xVersion' => '4.5.8',
             'xSoftwareName' => 'Magento ' . $edition . " ". $version,
-            'xSoftwareVersion' => '1.0.26',
+            'xSoftwareVersion' => '1.0.27',
             'xKey' => $this->config->getValue(
                 'cardknox_transaction_key',
                 $order->getStoreId()

--- a/Gateway/Request/GooglePayBaseRequest.php
+++ b/Gateway/Request/GooglePayBaseRequest.php
@@ -68,7 +68,7 @@ class GooglePayBaseRequest implements BuilderInterface
         return [
             'xVersion' => '4.5.8',
             'xSoftwareName' => $xSoftwareName,
-            'xSoftwareVersion' => '1.0.26',
+            'xSoftwareVersion' => '1.0.27',
             'xKey' => $this->config->getValue(
                 'cardknox_transaction_key',
                 $order->getStoreId()

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "cardknox/cardknox",
     "description": "Cardknox integration for Magento 2",
     "type": "magento2-module",
-    "version": "1.0.26",
+    "version": "1.0.27",
     "license": [
         "GPL-3.0"
     ],

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,7 @@
+1.0.27
+- Remove the Shipping method selection from Googlepay/ApplePay popup in cart page
+- Remove dynamic tax calculation from Googlepay/ApplePay popup in cart page
+
 1.0.26
 - Fix Error-Request_Client_IP  exceeds max lenght
 - IP not capture when site is on clouflare

--- a/view/adminhtml/web/cardknox.js
+++ b/view/adminhtml/web/cardknox.js
@@ -116,7 +116,7 @@ define([
             try {
                 //setAccount(this.saveOnlyKey, "Magento2", "0.1.2");
                 enableLogging();
-                setAccount(this.tokenKey, "Magento2", "1.0.26");
+                setAccount(this.tokenKey, "Magento2", "1.0.27");
                 enableAutoFormatting();
                 setIfieldStyle('card-number', self.defaultStyle);
                 setIfieldStyle('cvv', self.defaultStyle);

--- a/view/frontend/web/js/view/payment/method-renderer/cardknox-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cardknox-method.js
@@ -162,7 +162,7 @@ define(
                  * [Required]
                  * Set your account data using setAccount(ifieldKey, yourSoftwareName, yourSoftwareVersion).
                  */
-                setAccount(window.checkoutConfig.payment.cardknox.tokenKey, "Magento2", "1.0.26");
+                setAccount(window.checkoutConfig.payment.cardknox.tokenKey, "Magento2", "1.0.27");
 
                 /*
                  * [Optional]


### PR DESCRIPTION
This PR is for adding missing release notes for remove features from cart page for GooglePay and applepay

**Removed features:**

1. Remove the Shipping method selection from Googlepay/ApplePay popup in cart page
2. Remove dynamic tax calculation from Googlepay/ApplePay popup in cart page

Recently merged PR for this task is: https://github.com/cardknox/magento2_cardknox/pull/72