### PR TITLE
PLGN-177 Remove unsupported Verify 3DS parameter

### DIFF
--- a/Controller/Index/VerifyThreeDS.php
+++ b/Controller/Index/VerifyThreeDS.php
@@ -331,7 +331,7 @@ class VerifyThreeDS extends Action implements HttpPostActionInterface
             ->setFailSafe(true)
             ->build($transactionType);
 
-        
+
         $order->save();
         $transaction->save();
 
@@ -399,8 +399,6 @@ class VerifyThreeDS extends Action implements HttpPostActionInterface
                 'cardknox_transaction_key',
                 $storeId
             ),
-            'xIP' => $ipAddress,
-
         ];
 
         // Merge arrays, giving precedence to $newParams


### PR DESCRIPTION
1. Fix unsupported field xIP - Steps to reproduce: https://www.awesomescreenshot.com/video/41504917?key=e50356c2ffb96d5c4cdd2a72d3df62f5

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unsupported field `xIP` from request parameters in `VerifyThreeDS.php` to fix 3DS order placement issue.
> 
>   - **Behavior**:
>     - Removes unsupported field `xIP` from request parameters in `baseRequestParams()` in `VerifyThreeDS.php`. This resolves an issue when placing orders using 3DS.
>   - **Misc**:
>     - Minor whitespace cleanup in `VerifyThreeDS.php`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cardknox%2Fmagento2_cardknox&utm_source=github&utm_medium=referral)<sup> for 32c96cefa04328e24b9ad7be6fa31d606c31462d. You can [customize](https://app.ellipsis.dev/cardknox/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->