### PR TITLE
PLGN-182: Fix the payment method you requested is not available

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -11,6 +11,8 @@
                 <value id="cdn.cardknox.com" type="host">cdn.cardknox.com</value>
                 <value id="*.cardinalcommerce.com" type="host">*.cardinalcommerce.com</value>
                 <value id="www.gstatic.com" type="host">www.gstatic.com</value>
+                <value id="*.solapayments.com" type="host">*.solapayments.com</value>
+                <value id="*.cardknox.com" type="host">*.cardknox.com</value>
             </values>
         </policy>
         <policy id="frame-src">
@@ -18,6 +20,8 @@
                 <value id="cardknox-ifields" type="host">cdn.cardknox.com</value>
                 <value id="*.cardinalcommerce.com" type="host">*.cardinalcommerce.com</value>
                 <value id="pay.google.com" type="host">pay.google.com</value>
+                <value id="*.solapayments.com" type="host">*.solapayments.com</value>
+                <value id="*.cardknox.com" type="host">*.cardknox.com</value>
             </values>
         </policy>
         <policy id="style-src">
@@ -53,6 +57,8 @@
         <policy id="img-src">
             <values>
                 <value id="www.gstatic.com" type="host">www.gstatic.com</value>
+                <value id="*.solapayments.com" type="host">*.solapayments.com</value>
+                <value id="*.cardknox.com" type="host">*.cardknox.com</value>
             </values>
         </policy>
     </policies>


### PR DESCRIPTION
1. Fixed Content Policy Security Issue
2. Fixed the payment method you requested is not available

**Key Fixes:**
- **Payment Method Access**: Changed from `getMethodInstance()->getCode()` to getMethod() with safe fallback
- **Operator Precedence**: Fixed conditional logic from `$method == "cardknox_google_pay" || $method == "cardknox_apple_pay"` to proper array check
- **Null Checks**: Added validation for quote, payment, and address objects before processing
- **Exception Handling**: Wrapped all operations in try-catch to prevent plugin exceptions from breaking order placement
- **Method Validation**: Added a check to ensure the payment method exists before processing
- **Telephone Logic**: Fixed incorrect strstr() usage in telephone parsing
- **Early Returns**: Added proper exit points when conditions aren't met to skip unnecessary processing
- Added Logger Dependency

**Added Catch Blocks with Standard Magento Logging to Plugin file**
- **Critical logs**: For main plugin exceptions that could affect order placement
- **Error logs**: For specific method failures and exceptions