### PR TITLE
PLGN-209 Fix Duplicate Transaction redirect issue routing to No Route error page

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,12 +1,19 @@
 /**
  * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * See LICENSE for license details.
  */
 
 var config = {
     map: {
         '*': {
             giftCard: 'CardknoxDevelopment_Cardknox/js/view/cart/gift-card'
+        }
+    },
+    config: {
+        mixins: {
+            'Magento_Checkout/js/model/step-navigator': {
+                'CardknoxDevelopment_Cardknox/js/model/step-navigator-mixin': true
+            }
         }
     }
 };

--- a/view/frontend/web/js/model/step-navigator-mixin.js
+++ b/view/frontend/web/js/model/step-navigator-mixin.js
@@ -15,12 +15,11 @@ define([
          * Check if cart has only virtual products
          * @returns {boolean}
          */
-        var isVirtualQuote = function () {
-            return window.checkoutConfig &&
-                   window.checkoutConfig.quoteData &&
-                   (window.checkoutConfig.quoteData.is_virtual === '1' ||
-                    window.checkoutConfig.quoteData.is_virtual === 1 ||
-                    window.checkoutConfig.quoteData.is_virtual === true);
+        const isVirtualQuote = function () {
+            const quoteData = globalThis.checkoutConfig?.quoteData;
+            return quoteData?.is_virtual === '1' ||
+                   quoteData?.is_virtual === 1 ||
+                   quoteData?.is_virtual === true;
         };
 
         /**
@@ -38,16 +37,14 @@ define([
         /**
          * Override handleHash to prevent redirect to noroute for virtual products
          */
-        var originalHandleHash = stepNavigator.handleHash;
+        const originalHandleHash = stepNavigator.handleHash;
         stepNavigator.handleHash = function () {
-            var hashString = window.location.hash.replace('#', '');
+            const hashString = globalThis.location.hash.replace('#', '');
 
             // For virtual products, if hash is 'shipping', clear it and stay on current page
             if (isVirtualQuote() && hashString === 'shipping') {
                 // Remove the invalid hash without triggering navigation
-                if (window.history && window.history.replaceState) {
-                    window.history.replaceState(null, null, window.location.pathname + window.location.search);
-                }
+                globalThis.history?.replaceState(null, null, globalThis.location.pathname + globalThis.location.search);
                 return false;
             }
 

--- a/view/frontend/web/js/model/step-navigator-mixin.js
+++ b/view/frontend/web/js/model/step-navigator-mixin.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright © 2024 Cardknox Development Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * Mixin to prevent redirect to shipping step for virtual products on payment error
+ */
+define([
+    'jquery',
+    'mage/utils/wrapper'
+], function ($, wrapper) {
+    'use strict';
+
+    return function (stepNavigator) {
+        /**
+         * Check if cart has only virtual products
+         * @returns {boolean}
+         */
+        var isVirtualQuote = function () {
+            return window.checkoutConfig &&
+                   window.checkoutConfig.quoteData &&
+                   (window.checkoutConfig.quoteData.is_virtual === '1' ||
+                    window.checkoutConfig.quoteData.is_virtual === 1 ||
+                    window.checkoutConfig.quoteData.is_virtual === true);
+        };
+
+        /**
+         * Override setHash to prevent setting shipping hash for virtual products
+         */
+        stepNavigator.setHash = wrapper.wrap(stepNavigator.setHash, function (originalSetHash, hash) {
+            // For virtual products, don't allow setting hash to 'shipping'
+            if (isVirtualQuote() && hash === 'shipping') {
+                // Keep on payment step instead
+                return;
+            }
+            return originalSetHash(hash);
+        });
+
+        /**
+         * Override handleHash to prevent redirect to noroute for virtual products
+         */
+        var originalHandleHash = stepNavigator.handleHash;
+        stepNavigator.handleHash = function () {
+            var hashString = window.location.hash.replace('#', '');
+
+            // For virtual products, if hash is 'shipping', clear it and stay on current page
+            if (isVirtualQuote() && hashString === 'shipping') {
+                // Remove the invalid hash without triggering navigation
+                if (window.history && window.history.replaceState) {
+                    window.history.replaceState(null, null, window.location.pathname + window.location.search);
+                }
+                return false;
+            }
+
+            return originalHandleHash.call(this);
+        };
+
+        return stepNavigator;
+    };
+});

--- a/view/frontend/web/js/model/step-navigator-mixin.js
+++ b/view/frontend/web/js/model/step-navigator-mixin.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Cardknox Development Inc. All rights reserved.
+ * Copyright © 2026 Cardknox Development Inc. All rights reserved.
  * See LICENSE for license details.
  *
  * Mixin to prevent redirect to shipping step for virtual products on payment error

--- a/view/frontend/web/js/view/payment/cardknox-payment-helper.js
+++ b/view/frontend/web/js/view/payment/cardknox-payment-helper.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright © 2024 Cardknox Development Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * Shared helper functions for Cardknox payment methods
+ */
+define([
+    'Magento_Checkout/js/model/step-navigator'
+], function (stepNavigator) {
+    'use strict';
+
+    return {
+        /**
+         * Check if cart has only virtual products
+         * @returns {boolean}
+         */
+        isVirtualQuote: function () {
+            return window.checkoutConfig.quoteData &&
+                   (window.checkoutConfig.quoteData.is_virtual === '1' ||
+                    window.checkoutConfig.quoteData.is_virtual === 1 ||
+                    window.checkoutConfig.quoteData.is_virtual === true);
+        },
+
+        /**
+         * Save shipping method before placing order
+         */
+        saveShippingMethod: function () {
+            if (window.checkoutConfig.selectedShippingMethod) {
+                window.cardknoxSavedShippingMethod = window.checkoutConfig.selectedShippingMethod;
+            }
+
+            // For virtual products, set a dummy shipping method to prevent redirect to shipping step on error
+            if (this.isVirtualQuote() && !window.checkoutConfig.selectedShippingMethod) {
+                window.checkoutConfig.selectedShippingMethod = 'virtual';
+            }
+        },
+
+        /**
+         * Force stay on payment step after duplicate transaction error
+         * This prevents Magento from redirecting to shipping step
+         */
+        forceStayOnPayment: function () {
+            var self = this;
+            var isVirtual = this.isVirtualQuote();
+
+            // Restore shipping method if it was cleared
+            if (!window.checkoutConfig.selectedShippingMethod && window.cardknoxSavedShippingMethod) {
+                window.checkoutConfig.selectedShippingMethod = window.cardknoxSavedShippingMethod;
+            }
+
+            // Find the payment step and force it to be visible
+            var steps = stepNavigator.steps();
+            steps.forEach(function (step) {
+                if (step.code === 'payment') {
+                    step.isVisible(true);
+                } else {
+                    step.isVisible(false);
+                }
+            });
+
+            // For virtual products, don't change the hash - just keep payment visible
+            // For non-virtual products, set hash to payment
+            if (!isVirtual) {
+                var baseUrl = window.location.origin + window.location.pathname;
+                var targetUrl = baseUrl + '#payment';
+
+                if (window.location.hash !== '#payment') {
+                    window.history.replaceState(null, null, targetUrl);
+                }
+
+                // Monitor and prevent any navigation away from payment for 3 seconds
+                var protectionInterval = setInterval(function () {
+                    var currentHash = window.location.hash.replace('#', '');
+                    if (currentHash !== 'payment') {
+                        steps.forEach(function (step) {
+                            if (step.code === 'payment') {
+                                step.isVisible(true);
+                            } else {
+                                step.isVisible(false);
+                            }
+                        });
+                        window.history.replaceState(null, null, targetUrl);
+                    }
+                }, 50);
+
+                setTimeout(function () {
+                    clearInterval(protectionInterval);
+                }, 3000);
+            } else {
+                // For virtual products, just ensure payment is visible
+                var protectionInterval = setInterval(function () {
+                    steps.forEach(function (step) {
+                        if (step.code === 'payment') {
+                            step.isVisible(true);
+                        } else {
+                            step.isVisible(false);
+                        }
+                    });
+                }, 50);
+
+                setTimeout(function () {
+                    clearInterval(protectionInterval);
+                }, 3000);
+            }
+        }
+    };
+});

--- a/view/frontend/web/js/view/payment/cardknox-payment-helper.js
+++ b/view/frontend/web/js/view/payment/cardknox-payment-helper.js
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2024 Cardknox Development Inc. All rights reserved.
+ * Copyright © 2026 Cardknox Development Inc. All rights reserved.
  * See LICENSE for license details.
  *
  * Shared helper functions for Cardknox payment methods

--- a/view/frontend/web/js/view/payment/method-renderer/cardknox-apple-pay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cardknox-apple-pay-method.js
@@ -9,7 +9,7 @@ define([
     'Magento_Checkout/js/model/full-screen-loader',
     'Magento_Checkout/js/action/redirect-on-success',
     'Magento_Checkout/js/action/place-order',
-    'Magento_Checkout/js/model/step-navigator'
+    'CardknoxDevelopment_Cardknox/js/view/payment/cardknox-payment-helper'
 ], function (
     Component,
     quote,
@@ -21,7 +21,7 @@ define([
     fullScreenLoaderAP,
     redirectOnSuccessActionAP,
     placeOrderActionAP,
-    stepNavigator
+    cardknoxPaymentHelper
 ) {
     'use strict';
     window.checkoutConfig.reloadOnBillingAddress = true;
@@ -123,7 +123,7 @@ define([
             );
         },
         /**
-         * Place order.
+         * Place order with duplicate transaction protection
          */
         placeOrder: function (data, event) {
             let self = this;
@@ -133,20 +133,7 @@ define([
             }
 
             // Save shipping method before placing order
-            if (window.checkoutConfig.selectedShippingMethod) {
-                window.cardknoxSavedShippingMethod = window.checkoutConfig.selectedShippingMethod;
-            }
-
-            // For virtual products, set a dummy shipping method to prevent redirect to shipping step on error
-            // This is needed because Magento's payment.js navigate() checks hasShippingMethod()
-            var isVirtual = window.checkoutConfig.quoteData &&
-                           (window.checkoutConfig.quoteData.is_virtual === '1' ||
-                            window.checkoutConfig.quoteData.is_virtual === 1 ||
-                            window.checkoutConfig.quoteData.is_virtual === true);
-
-            if (isVirtual && !window.checkoutConfig.selectedShippingMethod) {
-                window.checkoutConfig.selectedShippingMethod = 'virtual';
-            }
+            cardknoxPaymentHelper.saveShippingMethod();
 
             if (this.validate() &&
                 additionalValidators.validate() &&
@@ -178,9 +165,7 @@ define([
 
                             if (errorMessage.startsWith('Duplicate Transaction')) {
                                 self.isAllowDuplicateTransaction(true);
-                                // Prevent redirect to shipping section on duplicate transaction error
-                                // Force payment step to be visible and stay on payment
-                                self.forceStayOnPayment();
+                                cardknoxPaymentHelper.forceStayOnPayment();
                             } else {
                                 self.isAllowDuplicateTransaction(false);
                             }
@@ -200,78 +185,6 @@ define([
 
             fullScreenLoaderAP.stopLoader();
             $('.checkout-cart-index .loading-mask').attr('style','display:none');
-        },
-
-        /**
-         * Force stay on payment step after duplicate transaction error
-         * This prevents Magento from redirecting to shipping step
-         */
-        forceStayOnPayment: function () {
-            var self = this;
-            var isVirtual = window.checkoutConfig.quoteData &&
-                           (window.checkoutConfig.quoteData.is_virtual === '1' ||
-                            window.checkoutConfig.quoteData.is_virtual === 1 ||
-                            window.checkoutConfig.quoteData.is_virtual === true);
-
-            // Store the current shipping method to prevent hasShippingMethod() from returning false
-            if (!window.checkoutConfig.selectedShippingMethod && window.cardknoxSavedShippingMethod) {
-                window.checkoutConfig.selectedShippingMethod = window.cardknoxSavedShippingMethod;
-            }
-
-            // Find the payment step and force it to be visible
-            var steps = stepNavigator.steps();
-            steps.forEach(function(step) {
-                if (step.code === 'payment') {
-                    step.isVisible(true);
-                } else {
-                    step.isVisible(false);
-                }
-            });
-
-            // For virtual products, don't change the hash - just keep payment visible
-            // For non-virtual products, set hash to payment
-            if (!isVirtual) {
-                var baseUrl = window.location.origin + window.location.pathname;
-                var targetUrl = baseUrl + '#payment';
-
-                if (window.location.hash !== '#payment') {
-                    window.history.replaceState(null, null, targetUrl);
-                }
-
-                // Monitor and prevent any navigation away from payment for 3 seconds (non-virtual only)
-                var protectionInterval = setInterval(function() {
-                    var currentHash = window.location.hash.replace('#', '');
-                    if (currentHash !== 'payment') {
-                        steps.forEach(function(step) {
-                            if (step.code === 'payment') {
-                                step.isVisible(true);
-                            } else {
-                                step.isVisible(false);
-                            }
-                        });
-                        window.history.replaceState(null, null, targetUrl);
-                    }
-                }, 50);
-
-                setTimeout(function() {
-                    clearInterval(protectionInterval);
-                }, 3000);
-            } else {
-                // For virtual products, just ensure payment is visible and prevent any navigation
-                var protectionInterval = setInterval(function() {
-                    steps.forEach(function(step) {
-                        if (step.code === 'payment') {
-                            step.isVisible(true);
-                        } else {
-                            step.isVisible(false);
-                        }
-                    });
-                }, 50);
-
-                setTimeout(function() {
-                    clearInterval(protectionInterval);
-                }, 3000);
-            }
         }
     });
 });

--- a/view/frontend/web/js/view/payment/method-renderer/cardknox-google-pay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cardknox-google-pay-method.js
@@ -7,7 +7,8 @@ define([
     "jquery",
     'Magento_Checkout/js/action/redirect-on-success',
     "ko",
-    'Magento_Checkout/js/action/place-order'
+    'Magento_Checkout/js/action/place-order',
+    'Magento_Checkout/js/model/step-navigator'
 ], function (
     Component,
     quote,
@@ -17,7 +18,8 @@ define([
     $,
     redirectOnSuccessActionGP,
     koForGP,
-    placeOrderActionGP
+    placeOrderActionGP,
+    stepNavigator
 ) {
     'use strict';
     window.checkoutConfig.reloadOnBillingAddress = true;
@@ -116,14 +118,112 @@ define([
                 placeOrderActionGP(this.getData(), this.messageContainer)
             );
         },
+        showPaymentError: function (message) {
+            $(".gpay-error").html("<div> "+message+" </div>").show();
+            setTimeout(function () {
+                $(".gpay-error").html("").hide();
+            }, 5000);
+
+            fullScreenLoader.stopLoader();
+            $('.checkout-cart-index .loading-mask').attr('style','display:none');
+        },
+
         /**
-         * Place order.
+         * Force stay on payment step after duplicate transaction error
+         * This prevents Magento from redirecting to shipping step
+         */
+        forceStayOnPayment: function () {
+            var self = this;
+            var isVirtual = window.checkoutConfig.quoteData &&
+                           (window.checkoutConfig.quoteData.is_virtual === '1' ||
+                            window.checkoutConfig.quoteData.is_virtual === 1 ||
+                            window.checkoutConfig.quoteData.is_virtual === true);
+
+            // Store the current shipping method to prevent hasShippingMethod() from returning false
+            if (!window.checkoutConfig.selectedShippingMethod && window.cardknoxSavedShippingMethod) {
+                window.checkoutConfig.selectedShippingMethod = window.cardknoxSavedShippingMethod;
+            }
+
+            // Find the payment step and force it to be visible
+            var steps = stepNavigator.steps();
+            steps.forEach(function(step) {
+                if (step.code === 'payment') {
+                    step.isVisible(true);
+                } else {
+                    step.isVisible(false);
+                }
+            });
+
+            // For virtual products, don't change the hash - just keep payment visible
+            // For non-virtual products, set hash to payment
+            if (!isVirtual) {
+                var baseUrl = window.location.origin + window.location.pathname;
+                var targetUrl = baseUrl + '#payment';
+
+                if (window.location.hash !== '#payment') {
+                    window.history.replaceState(null, null, targetUrl);
+                }
+
+                // Monitor and prevent any navigation away from payment for 3 seconds (non-virtual only)
+                var protectionInterval = setInterval(function() {
+                    var currentHash = window.location.hash.replace('#', '');
+                    if (currentHash !== 'payment') {
+                        steps.forEach(function(step) {
+                            if (step.code === 'payment') {
+                                step.isVisible(true);
+                            } else {
+                                step.isVisible(false);
+                            }
+                        });
+                        window.history.replaceState(null, null, targetUrl);
+                    }
+                }, 50);
+
+                setTimeout(function() {
+                    clearInterval(protectionInterval);
+                }, 3000);
+            } else {
+                // For virtual products, just ensure payment is visible and prevent any navigation
+                var protectionInterval = setInterval(function() {
+                    steps.forEach(function(step) {
+                        if (step.code === 'payment') {
+                            step.isVisible(true);
+                        } else {
+                            step.isVisible(false);
+                        }
+                    });
+                }, 50);
+
+                setTimeout(function() {
+                    clearInterval(protectionInterval);
+                }, 3000);
+            }
+        },
+
+        /**
+         * Override placeOrder to save shipping method before attempting order
          */
         placeOrder: function (data, event) {
             let self = this;
 
             if (event) {
                 event.preventDefault();
+            }
+
+            // Save shipping method before placing order
+            if (window.checkoutConfig.selectedShippingMethod) {
+                window.cardknoxSavedShippingMethod = window.checkoutConfig.selectedShippingMethod;
+            }
+
+            // For virtual products, set a dummy shipping method to prevent redirect to shipping step on error
+            // This is needed because Magento's payment.js navigate() checks hasShippingMethod()
+            var isVirtual = window.checkoutConfig.quoteData &&
+                           (window.checkoutConfig.quoteData.is_virtual === '1' ||
+                            window.checkoutConfig.quoteData.is_virtual === 1 ||
+                            window.checkoutConfig.quoteData.is_virtual === true);
+
+            if (isVirtual && !window.checkoutConfig.selectedShippingMethod) {
+                window.checkoutConfig.selectedShippingMethod = 'virtual';
             }
 
             if (this.validate() &&
@@ -156,25 +256,19 @@ define([
 
                             if (error_message.startsWith('Duplicate Transaction')) {
                                 self.isAllowDuplicateTransaction(true);
+                                // Prevent redirect to shipping section on duplicate transaction error
+                                // Force payment step to be visible and stay on payment
+                                self.forceStayOnPayment();
                             } else {
                                 self.isAllowDuplicateTransaction(false);
                             }
                         }
-                    );;
+                    );
 
                 return true;
             }
 
             return false;
-        },
-        showPaymentError: function (message) {
-            $(".gpay-error").html("<div> "+message+" </div>").show();
-            setTimeout(function () { 
-                $(".gpay-error").html("").hide();
-            }, 5000);
-            
-            fullScreenLoader.stopLoader();
-            $('.checkout-cart-index .loading-mask').attr('style','display:none');
         }
     });
 });

--- a/view/frontend/web/js/view/payment/method-renderer/cardknox-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cardknox-method.js
@@ -17,7 +17,8 @@ define(
         'ko',
         'Magento_Checkout/js/action/redirect-on-success',
         'Magento_Checkout/js/model/payment/additional-validators',
-        'mage/url'
+        'mage/url',
+        'Magento_Checkout/js/model/step-navigator'
     ],
     function (
         Component,
@@ -31,7 +32,8 @@ define(
         ko,
         redirectOnSuccessAction,
         additionalValidators,
-        urlBuilder
+        urlBuilder,
+        stepNavigator
     ) {
         'use strict';
 
@@ -380,6 +382,23 @@ define(
                     event.preventDefault();
                 }
                 var self = this;
+
+                // Save shipping method before placing order
+                if (window.checkoutConfig.selectedShippingMethod) {
+                    window.cardknoxSavedShippingMethod = window.checkoutConfig.selectedShippingMethod;
+                }
+
+                // For virtual products, set a dummy shipping method to prevent redirect to shipping step on error
+                // This is needed because Magento's payment.js navigate() checks hasShippingMethod()
+                var isVirtual = window.checkoutConfig.quoteData &&
+                               (window.checkoutConfig.quoteData.is_virtual === '1' ||
+                                window.checkoutConfig.quoteData.is_virtual === 1 ||
+                                window.checkoutConfig.quoteData.is_virtual === true);
+
+                if (isVirtual && !window.checkoutConfig.selectedShippingMethod) {
+                    window.checkoutConfig.selectedShippingMethod = 'virtual';
+                }
+
                 var isEnabledGoogleReCaptcha = this.isEnabledReCaptcha();
                 if (isEnabledGoogleReCaptcha == true){
                     var captchResponse = $('#cardknox_recaptcha .g-recaptcha-response').val();
@@ -522,6 +541,9 @@ define(
                                             const error = response.responseJSON?.message;
                                             if (error && error.startsWith('Duplicate Transaction')) {
                                                 self.isAllowDuplicateTransaction(true);
+                                                // Prevent redirect to shipping section on duplicate transaction error
+                                                // Force payment step to be visible and stay on payment
+                                                self.forceStayOnPayment();
                                             } else {
                                                 self.isAllowDuplicateTransaction(false);
                                             }
@@ -586,6 +608,78 @@ define(
                     }
                 }
                 return isAllowDuplicateTransactionCC;
+            },
+
+            /**
+             * Force stay on payment step after duplicate transaction error
+             * This prevents Magento from redirecting to shipping step
+             */
+            forceStayOnPayment: function () {
+                var self = this;
+                var isVirtual = window.checkoutConfig.quoteData &&
+                               (window.checkoutConfig.quoteData.is_virtual === '1' ||
+                                window.checkoutConfig.quoteData.is_virtual === 1 ||
+                                window.checkoutConfig.quoteData.is_virtual === true);
+
+                // Store the current shipping method to prevent hasShippingMethod() from returning false
+                if (!window.checkoutConfig.selectedShippingMethod && window.cardknoxSavedShippingMethod) {
+                    window.checkoutConfig.selectedShippingMethod = window.cardknoxSavedShippingMethod;
+                }
+
+                // Find the payment step and force it to be visible
+                var steps = stepNavigator.steps();
+                steps.forEach(function(step) {
+                    if (step.code === 'payment') {
+                        step.isVisible(true);
+                    } else {
+                        step.isVisible(false);
+                    }
+                });
+
+                // For virtual products, don't change the hash - just keep payment visible
+                // For non-virtual products, set hash to payment
+                if (!isVirtual) {
+                    var baseUrl = window.location.origin + window.location.pathname;
+                    var targetUrl = baseUrl + '#payment';
+
+                    if (window.location.hash !== '#payment') {
+                        window.history.replaceState(null, null, targetUrl);
+                    }
+
+                    // Monitor and prevent any navigation away from payment for 3 seconds (non-virtual only)
+                    var protectionInterval = setInterval(function() {
+                        var currentHash = window.location.hash.replace('#', '');
+                        if (currentHash !== 'payment') {
+                            steps.forEach(function(step) {
+                                if (step.code === 'payment') {
+                                    step.isVisible(true);
+                                } else {
+                                    step.isVisible(false);
+                                }
+                            });
+                            window.history.replaceState(null, null, targetUrl);
+                        }
+                    }, 50);
+
+                    setTimeout(function() {
+                        clearInterval(protectionInterval);
+                    }, 3000);
+                } else {
+                    // For virtual products, just ensure payment is visible and prevent any navigation
+                    var protectionInterval = setInterval(function() {
+                        steps.forEach(function(step) {
+                            if (step.code === 'payment') {
+                                step.isVisible(true);
+                            } else {
+                                step.isVisible(false);
+                            }
+                        });
+                    }, 50);
+
+                    setTimeout(function() {
+                        clearInterval(protectionInterval);
+                    }, 3000);
+                }
             }
         });
     }

--- a/view/frontend/web/js/view/payment/method-renderer/vault.js
+++ b/view/frontend/web/js/view/payment/method-renderer/vault.js
@@ -10,8 +10,8 @@ define([
     'Magento_Checkout/js/action/redirect-on-success',
     'Magento_Checkout/js/model/full-screen-loader',
     'Magento_Checkout/js/action/place-order',
-    'Magento_Checkout/js/model/step-navigator'
-], function (VaultComponent,additionalValidators,$,knockout,redirectOnSuccessActionVault,fullScreenLoaderVault,placeOrderActionVault,stepNavigator) {
+    'CardknoxDevelopment_Cardknox/js/view/payment/cardknox-payment-helper'
+], function (VaultComponent, additionalValidators, $, knockout, redirectOnSuccessActionVault, fullScreenLoaderVault, placeOrderActionVault, cardknoxPaymentHelper) {
     'use strict';
 
     return VaultComponent.extend({
@@ -92,7 +92,7 @@ define([
             );
         },
         /**
-         * Place order.
+         * Place order with duplicate transaction protection
          */
         placeOrder: function (data, event) {
             let self = this;
@@ -102,20 +102,7 @@ define([
             }
 
             // Save shipping method before placing order
-            if (window.checkoutConfig.selectedShippingMethod) {
-                window.cardknoxSavedShippingMethod = window.checkoutConfig.selectedShippingMethod;
-            }
-
-            // For virtual products, set a dummy shipping method to prevent redirect to shipping step on error
-            // This is needed because Magento's payment.js navigate() checks hasShippingMethod()
-            var isVirtual = window.checkoutConfig.quoteData &&
-                           (window.checkoutConfig.quoteData.is_virtual === '1' ||
-                            window.checkoutConfig.quoteData.is_virtual === 1 ||
-                            window.checkoutConfig.quoteData.is_virtual === true);
-
-            if (isVirtual && !window.checkoutConfig.selectedShippingMethod) {
-                window.checkoutConfig.selectedShippingMethod = 'virtual';
-            }
+            cardknoxPaymentHelper.saveShippingMethod();
 
             if (this.validate() &&
                 additionalValidators.validate() &&
@@ -147,9 +134,7 @@ define([
                             self.showPaymentError(error_message);
                             if (error_message.startsWith('Duplicate Transaction')) {
                                 self.isAllowDuplicateTransactionVault(true);
-                                // Prevent redirect to shipping section on duplicate transaction error
-                                // Force payment step to be visible and stay on payment
-                                self.forceStayOnPayment();
+                                cardknoxPaymentHelper.forceStayOnPayment();
                             } else {
                                 self.isAllowDuplicateTransactionVault(false);
                             }
@@ -175,78 +160,6 @@ define([
              */
         getIdAllowDuplicateTransaction: function () {
             return "is_allow_duplicate_transaction_"+this.index;
-        },
-
-        /**
-         * Force stay on payment step after duplicate transaction error
-         * This prevents Magento from redirecting to shipping step
-         */
-        forceStayOnPayment: function () {
-            var self = this;
-            var isVirtual = window.checkoutConfig.quoteData &&
-                           (window.checkoutConfig.quoteData.is_virtual === '1' ||
-                            window.checkoutConfig.quoteData.is_virtual === 1 ||
-                            window.checkoutConfig.quoteData.is_virtual === true);
-
-            // Store the current shipping method to prevent hasShippingMethod() from returning false
-            if (!window.checkoutConfig.selectedShippingMethod && window.cardknoxSavedShippingMethod) {
-                window.checkoutConfig.selectedShippingMethod = window.cardknoxSavedShippingMethod;
-            }
-
-            // Find the payment step and force it to be visible
-            var steps = stepNavigator.steps();
-            steps.forEach(function(step) {
-                if (step.code === 'payment') {
-                    step.isVisible(true);
-                } else {
-                    step.isVisible(false);
-                }
-            });
-
-            // For virtual products, don't change the hash - just keep payment visible
-            // For non-virtual products, set hash to payment
-            if (!isVirtual) {
-                var baseUrl = window.location.origin + window.location.pathname;
-                var targetUrl = baseUrl + '#payment';
-
-                if (window.location.hash !== '#payment') {
-                    window.history.replaceState(null, null, targetUrl);
-                }
-
-                // Monitor and prevent any navigation away from payment for 3 seconds (non-virtual only)
-                var protectionInterval = setInterval(function() {
-                    var currentHash = window.location.hash.replace('#', '');
-                    if (currentHash !== 'payment') {
-                        steps.forEach(function(step) {
-                            if (step.code === 'payment') {
-                                step.isVisible(true);
-                            } else {
-                                step.isVisible(false);
-                            }
-                        });
-                        window.history.replaceState(null, null, targetUrl);
-                    }
-                }, 50);
-
-                setTimeout(function() {
-                    clearInterval(protectionInterval);
-                }, 3000);
-            } else {
-                // For virtual products, just ensure payment is visible and prevent any navigation
-                var protectionInterval = setInterval(function() {
-                    steps.forEach(function(step) {
-                        if (step.code === 'payment') {
-                            step.isVisible(true);
-                        } else {
-                            step.isVisible(false);
-                        }
-                    });
-                }, 50);
-
-                setTimeout(function() {
-                    clearInterval(protectionInterval);
-                }, 3000);
-            }
         }
     });
 });

--- a/view/frontend/web/js/view/payment/method-renderer/vault.js
+++ b/view/frontend/web/js/view/payment/method-renderer/vault.js
@@ -9,8 +9,9 @@ define([
     "ko",
     'Magento_Checkout/js/action/redirect-on-success',
     'Magento_Checkout/js/model/full-screen-loader',
-    'Magento_Checkout/js/action/place-order'
-], function (VaultComponent,additionalValidators,$,knockout,redirectOnSuccessActionVault,fullScreenLoaderVault,placeOrderActionVault) {
+    'Magento_Checkout/js/action/place-order',
+    'Magento_Checkout/js/model/step-navigator'
+], function (VaultComponent,additionalValidators,$,knockout,redirectOnSuccessActionVault,fullScreenLoaderVault,placeOrderActionVault,stepNavigator) {
     'use strict';
 
     return VaultComponent.extend({
@@ -100,6 +101,22 @@ define([
                 event.preventDefault();
             }
 
+            // Save shipping method before placing order
+            if (window.checkoutConfig.selectedShippingMethod) {
+                window.cardknoxSavedShippingMethod = window.checkoutConfig.selectedShippingMethod;
+            }
+
+            // For virtual products, set a dummy shipping method to prevent redirect to shipping step on error
+            // This is needed because Magento's payment.js navigate() checks hasShippingMethod()
+            var isVirtual = window.checkoutConfig.quoteData &&
+                           (window.checkoutConfig.quoteData.is_virtual === '1' ||
+                            window.checkoutConfig.quoteData.is_virtual === 1 ||
+                            window.checkoutConfig.quoteData.is_virtual === true);
+
+            if (isVirtual && !window.checkoutConfig.selectedShippingMethod) {
+                window.checkoutConfig.selectedShippingMethod = 'virtual';
+            }
+
             if (this.validate() &&
                 additionalValidators.validate() &&
                 this.isPlaceOrderActionAllowed() === true
@@ -128,13 +145,16 @@ define([
                                 error_message = response.responseJSON.message;
                             }
                             self.showPaymentError(error_message);
-                            if (error_message == 'Duplicate Transaction') {
+                            if (error_message.startsWith('Duplicate Transaction')) {
                                 self.isAllowDuplicateTransactionVault(true);
+                                // Prevent redirect to shipping section on duplicate transaction error
+                                // Force payment step to be visible and stay on payment
+                                self.forceStayOnPayment();
                             } else {
                                 self.isAllowDuplicateTransactionVault(false);
                             }
                         }
-                    );;
+                    );
 
                 return true;
             }
@@ -143,7 +163,7 @@ define([
         },
         showPaymentError: function (message) {
             $(".ck-vault-error").html("<div> "+message+" </div>").show();
-            setTimeout(function () { 
+            setTimeout(function () {
                 $(".ck-vault-error").html("").hide();
             }, 5000);
 
@@ -156,7 +176,77 @@ define([
         getIdAllowDuplicateTransaction: function () {
             return "is_allow_duplicate_transaction_"+this.index;
         },
+
+        /**
+         * Force stay on payment step after duplicate transaction error
+         * This prevents Magento from redirecting to shipping step
+         */
+        forceStayOnPayment: function () {
+            var self = this;
+            var isVirtual = window.checkoutConfig.quoteData &&
+                           (window.checkoutConfig.quoteData.is_virtual === '1' ||
+                            window.checkoutConfig.quoteData.is_virtual === 1 ||
+                            window.checkoutConfig.quoteData.is_virtual === true);
+
+            // Store the current shipping method to prevent hasShippingMethod() from returning false
+            if (!window.checkoutConfig.selectedShippingMethod && window.cardknoxSavedShippingMethod) {
+                window.checkoutConfig.selectedShippingMethod = window.cardknoxSavedShippingMethod;
+            }
+
+            // Find the payment step and force it to be visible
+            var steps = stepNavigator.steps();
+            steps.forEach(function(step) {
+                if (step.code === 'payment') {
+                    step.isVisible(true);
+                } else {
+                    step.isVisible(false);
+                }
+            });
+
+            // For virtual products, don't change the hash - just keep payment visible
+            // For non-virtual products, set hash to payment
+            if (!isVirtual) {
+                var baseUrl = window.location.origin + window.location.pathname;
+                var targetUrl = baseUrl + '#payment';
+
+                if (window.location.hash !== '#payment') {
+                    window.history.replaceState(null, null, targetUrl);
+                }
+
+                // Monitor and prevent any navigation away from payment for 3 seconds (non-virtual only)
+                var protectionInterval = setInterval(function() {
+                    var currentHash = window.location.hash.replace('#', '');
+                    if (currentHash !== 'payment') {
+                        steps.forEach(function(step) {
+                            if (step.code === 'payment') {
+                                step.isVisible(true);
+                            } else {
+                                step.isVisible(false);
+                            }
+                        });
+                        window.history.replaceState(null, null, targetUrl);
+                    }
+                }, 50);
+
+                setTimeout(function() {
+                    clearInterval(protectionInterval);
+                }, 3000);
+            } else {
+                // For virtual products, just ensure payment is visible and prevent any navigation
+                var protectionInterval = setInterval(function() {
+                    steps.forEach(function(step) {
+                        if (step.code === 'payment') {
+                            step.isVisible(true);
+                        } else {
+                            step.isVisible(false);
+                        }
+                    });
+                }, 50);
+
+                setTimeout(function() {
+                    clearInterval(protectionInterval);
+                }, 3000);
+            }
+        }
     });
 });
-
-


### PR DESCRIPTION
## Summary                                                              
Fix checkout redirect issue where Duplicate Transaction error causes page to redirect to No Route error page instead of staying on payment step.
   
## Issues                                                               
- When Duplicate Transaction error occurs, checkout redirects to `#shipping` section                                                       
- For virtual products, shipping step does not exist, causing redirect to `/checkout/noroute/`                                                   
- Magento `payment.js` **navigate()** checks `hasShippingMethod()` which returns `false` on error, triggering redirect                                    
- Physical products redirect to shipping section instead of staying on payment section                                                         
   
## Solution                                                             
- Created `step-navigator-mixin.js` to intercept and block shipping hash navigation for virtual products
- Added `forceStayOnPayment()` function to maintain payment step visibility after error                                                  
- Implemented separate navigation protection logic for virtual and non-virtual products                                                    
- **Applied fix to all payment methods**: `Credit Card`, `Google Pay`, `Apple Pay`, and `Vault `
- Set dummy shipping method for virtual products before placing order
- **Dummy shipping method** - Secondary fallback protection for virtual products
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes checkout redirect issue on duplicate transaction errors, ensuring users remain on the payment step for virtual and non-virtual products.
> 
>   - **Behavior**:
>     - Fixes redirect issue on duplicate transaction error to prevent navigation to `#shipping` or `/checkout/noroute/`.
>     - Ensures users remain on payment step for both virtual and non-virtual products.
>   - **Implementation**:
>     - Adds `step-navigator-mixin.js` to block shipping hash navigation for virtual products.
>     - Introduces `forceStayOnPayment()` in `cardknox-apple-pay-method.js`, `cardknox-google-pay-method.js`, `cardknox-method.js`, and `vault.js` to maintain payment step visibility.
>     - Sets dummy shipping method for virtual products to prevent erroneous redirects.
>   - **Payment Methods**:
>     - Applies fixes to `Credit Card`, `Google Pay`, `Apple Pay`, and `Vault` methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cardknox%2Fmagento2_cardknox&utm_source=github&utm_medium=referral)<sup> for 99802c79d99b961b9edfc8b64c8f5a59b08220c7. You can [customize](https://app.ellipsis.dev/cardknox/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->