### PR TITLE
2.84 Version

### DIFF
--- a/Controller/Index/VerifyThreeDS.php
+++ b/Controller/Index/VerifyThreeDS.php
@@ -392,7 +392,7 @@ class VerifyThreeDS extends Action implements HttpPostActionInterface
         $newParams = [
             'xVersion' => '5.0.0',
             'xSoftwareName' => 'Magento ' . $edition . " ". $version,
-            'xSoftwareVersion' => '1.2.83',
+            'xSoftwareVersion' => '1.2.84',
             'xAllowDuplicate' => 1,
             'xKey' => $this->config->getValue(
                 'cardknox_transaction_key',

--- a/Gateway/Request/ApplePayBaseRequest.php
+++ b/Gateway/Request/ApplePayBaseRequest.php
@@ -68,7 +68,7 @@ class ApplePayBaseRequest implements BuilderInterface
         return [
             'xVersion' => '5.0.0',
             'xSoftwareName' => $xSoftwareName,
-            'xSoftwareVersion' => '1.2.83',
+            'xSoftwareVersion' => '1.2.84',
             'xKey' => $this->config->getValue(
                 'cardknox_transaction_key',
                 $order->getStoreId()

--- a/Gateway/Request/BaseRequest.php
+++ b/Gateway/Request/BaseRequest.php
@@ -69,7 +69,7 @@ class BaseRequest implements BuilderInterface
         return [
             'xVersion' => '5.0.0',
             'xSoftwareName' => 'Magento ' . $edition . " ". $version,
-            'xSoftwareVersion' => '1.2.83',
+            'xSoftwareVersion' => '1.2.84',
             'xKey' => $this->config->getValue(
                 'cardknox_transaction_key',
                 $order->getStoreId()

--- a/Gateway/Request/GooglePayBaseRequest.php
+++ b/Gateway/Request/GooglePayBaseRequest.php
@@ -68,7 +68,7 @@ class GooglePayBaseRequest implements BuilderInterface
         return [
             'xVersion' => '5.0.0',
             'xSoftwareName' => $xSoftwareName,
-            'xSoftwareVersion' => '1.2.83',
+            'xSoftwareVersion' => '1.2.84',
             'xKey' => $this->config->getValue(
                 'cardknox_transaction_key',
                 $order->getStoreId()

--- a/Helper/Giftcard.php
+++ b/Helper/Giftcard.php
@@ -18,7 +18,7 @@ class Giftcard extends AbstractHelper
     public const CARDKNOX_TRANSACTION_KEY = 'payment/cardknox/cardknox_transaction_key';
     public const CARDKNOX_X_VERSION = "5.0.0";
     public const CONTENT_TYPE = "application/json";
-    public const XSOFTWARE_VERSION = "1.2.83";
+    public const XSOFTWARE_VERSION = "1.2.84";
 
     /**
      * @var Curl

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "cardknox/cardknox",
     "description": "Cardknox integration for Magento 2",
     "type": "magento2-module",
-    "version": "1.2.83",
+    "version": "1.2.84",
     "license": [
         "MIT"
     ],

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,8 +1,8 @@
 1.2.84
 - Create create_release_zip.ps1
-- PLGN-202: Fix PHP CodeSniffer issues for cardknox plugin version 1.2.83
-- PLGN-204 Magento - Update GitHub Actions Workflow: Add PHPCS, Upgrade to PHP 8.4
-- PLGN-200 Enhance release script with dynamic naming from composer.json and cross-platform support
+- Fix PHP CodeSniffer issues for cardknox plugin version 1.2.83
+- Magento - Update GitHub Actions Workflow: Add PHPCS, Upgrade to PHP 8.4
+- Enhance release script with dynamic naming from composer.json and cross-platform support
 - Update README.md
 
 1.2.83

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,10 @@
+1.2.84
+- Create create_release_zip.ps1
+- PLGN-202: Fix PHP CodeSniffer issues for cardknox plugin version 1.2.83
+- PLGN-204 Magento - Update GitHub Actions Workflow: Add PHPCS, Upgrade to PHP 8.4
+- PLGN-200 Enhance release script with dynamic naming from composer.json and cross-platform support
+- Update README.md
+
 1.2.83
 - Updated Cardknox references to Sola for consistency across the platform.
 - Fixed issue causing subscription renewals to fail with "payment method not available."

--- a/view/adminhtml/web/cardknox.js
+++ b/view/adminhtml/web/cardknox.js
@@ -115,7 +115,7 @@ define([
             var self = this;
             try {
                 enableLogging();
-                setAccount(this.tokenKey, "Magento2", "1.2.83");
+                setAccount(this.tokenKey, "Magento2", "1.2.84");
                 enableAutoFormatting();
                 setIfieldStyle('card-number', self.defaultStyle);
                 setIfieldStyle('cvv', self.defaultStyle);

--- a/view/frontend/web/js/view/payment/method-renderer/cardknox-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cardknox-method.js
@@ -287,7 +287,7 @@ define(
                  * [Required]
                  * Set your account data using setAccount(ifieldKey, yourSoftwareName, yourSoftwareVersion).
                  */
-                setAccount(window.checkoutConfig.payment.cardknox.tokenKey, "Magento2", "1.2.83");
+                setAccount(window.checkoutConfig.payment.cardknox.tokenKey, "Magento2", "1.2.84");
 
                 /*
                  * [Optional]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update Cardknox integration version to 1.2.84, reflecting changes in multiple files and updating release notes.
> 
>   - **Version Update**:
>     - Update `xSoftwareVersion` from '1.2.83' to '1.2.84' in `VerifyThreeDS.php`, `ApplePayBaseRequest.php`, `BaseRequest.php`, `GooglePayBaseRequest.php`, `Giftcard.php`, `cardknox.js`, and `cardknox-method.js`.
>     - Update `version` in `composer.json` to '1.2.84'.
>   - **Release Notes**:
>     - Add version 1.2.84 details in `release_notes.txt`, including script creation, PHP CodeSniffer fixes, GitHub Actions updates, and README updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cardknox%2Fmagento2_cardknox&utm_source=github&utm_medium=referral)<sup> for f213944d20abebb9db4958403331ea4431c9df0d. You can [customize](https://app.ellipsis.dev/cardknox/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->