### PR TITLE
PLGN-212 Update latest stable iField version 3.3.2601.2901 to magento cardknox plugin

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -3,13 +3,14 @@
     <policies>
         <policy id="script-src">
             <values>
-                <value id="cardknox-ifields-script" type="host">https://cdn.cardknox.com/ifields/3.1.2508.1401/ifields.min.js</value>
-                <value id="cardknox-3ds-script" type="host">https://cdn.cardknox.com/sdk-3ds/1.0.2203.2501-beta/cardknox-3ds.min.js</value>
+                <value id="cardknox-ifields-script" type="host">https://cdn.cardknox.com/ifields/3.3.2601.2901/ifields.min.js</value>
+                <value id="cardknox-3ds-script" type="host">https://cdn.cardknox.com/sdk-3ds/1.1.2601.0701/cardknox-3ds.min.js</value>
                 <value id="fue-source" type="host">*.googleapis.com</value>
                 <value id="google-source" type="host">*.google.com</value>
                 <value id="gstatic-source" type="host">*.gstatic.com</value>
                 <value id="cdn.cardknox.com" type="host">cdn.cardknox.com</value>
                 <value id="*.cardinalcommerce.com" type="host">*.cardinalcommerce.com</value>
+                <value id="*.cardinaltrusted.com" type="host">*.cardinaltrusted.com</value>
                 <value id="www.gstatic.com" type="host">www.gstatic.com</value>
                 <value id="*.solapayments.com" type="host">*.solapayments.com</value>
                 <value id="*.cardknox.com" type="host">*.cardknox.com</value>
@@ -19,6 +20,7 @@
             <values>
                 <value id="cardknox-ifields" type="host">cdn.cardknox.com</value>
                 <value id="*.cardinalcommerce.com" type="host">*.cardinalcommerce.com</value>
+                <value id="*.cardinaltrusted.com" type="host">*.cardinaltrusted.com</value>
                 <value id="pay.google.com" type="host">pay.google.com</value>
                 <value id="*.solapayments.com" type="host">*.solapayments.com</value>
                 <value id="*.cardknox.com" type="host">*.cardknox.com</value>
@@ -48,10 +50,17 @@
                 <value id="gstatic-connect" type="host">https://www.gstatic.com</value>
                 <value id="api.cardknox.com" type="host">api.cardknox.com</value>
                 <value id="*.cardinalcommerce.com" type="host">*.cardinalcommerce.com</value>
+                <value id="*.cardinaltrusted.com-connect" type="host">*.cardinaltrusted.com</value>
                 <value id="kg668dbov0.execute-api.us-east-1.amazonaws.com" type="host">kg668dbov0.execute-api.us-east-1.amazonaws.com</value>
                 <value id="pay.google.com" type="host">pay.google.com</value>
                 <value id="play.google.com" type="host">play.google.com</value>
                 <value id="connect-cardknox" type="host">cdn.cardknox.com/</value>
+            </values>
+        </policy>
+        <policy id="form-action">
+            <values>
+                <value id="*.cardinalcommerce.com-form" type="host">*.cardinalcommerce.com</value>
+                <value id="*.cardinaltrusted.com-form" type="host">*.cardinaltrusted.com</value>
             </values>
         </policy>
         <policy id="img-src">

--- a/view/adminhtml/templates/form/cc.phtml
+++ b/view/adminhtml/templates/form/cc.phtml
@@ -23,7 +23,7 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
         </label>
         <div class="admin__field-control">
             <iframe data-ifields-id="card-number" data-ifields-placeholder="Card Number"
-                    src="https://cdn.cardknox.com/ifields/3.1.2508.1401/ifield.htm" frameBorder="0"
+                    src="https://cdn.cardknox.com/ifields/3.3.2601.2901/ifield.htm" frameBorder="0"
                     height="35"></iframe>
             <input data-ifields-id="card-number-token" name="payment[xCardNum]" type="hidden"/>
         </div>
@@ -61,7 +61,7 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
             </label>
             <div class="admin__field-control">
                 <iframe data-ifields-id="cvv" data-ifields-placeholder="CVV"
-                        src="https://cdn.cardknox.com/ifields/3.1.2508.1401/ifield.htm" frameBorder="0"
+                        src="https://cdn.cardknox.com/ifields/3.3.2601.2901/ifield.htm" frameBorder="0"
                         height="35"></iframe>
                 <input data-ifields-id="cvv-token" name="payment[xCVV]" type="hidden"/>
                 <label id="ifieldsError" data-ifields-id="card-data-error"></label>

--- a/view/base/requirejs-config.js
+++ b/view/base/requirejs-config.js
@@ -4,6 +4,6 @@
  */
  var config = {
     paths: {
-        ifields: 'https://cdn.cardknox.com/ifields/3.1.2508.1401/ifields.min'
+        ifields: 'https://cdn.cardknox.com/ifields/3.3.2601.2901/ifields.min'
     }
 };

--- a/view/frontend/web/template/cart/google-pay-btn.html
+++ b/view/frontend/web/template/cart/google-pay-btn.html
@@ -7,7 +7,7 @@
                             class="gp"
                             data-ifields-id="igp"
                             afterRender="initFrame()"
-                            src="https://cdn.cardknox.com/ifields/3.1.2508.1401/igp.htm"
+                            src="https://cdn.cardknox.com/ifields/3.3.2601.2901/igp.htm"
                             allowpaymentrequest
                             sandbox="allow-popups allow-modals allow-scripts allow-same-origin allow-forms allow-popups-to-escape-sandbox allow-top-navigation"
                             title="GPay checkout page">

--- a/view/frontend/web/template/payment/cardknox-form.html
+++ b/view/frontend/web/template/payment/cardknox-form.html
@@ -35,7 +35,7 @@
                     </label>
                     <div class="control">
                         <iframe data-ifields-id="card-number" data-ifields-placeholder="Card Number"
-                                src="https://cdn.cardknox.com/ifields/3.1.2508.1401/ifield.htm" frameBorder="0"
+                                src="https://cdn.cardknox.com/ifields/3.3.2601.2901/ifield.htm" frameBorder="0"
                                 height="35"></iframe>
                         <input data-ifields-id="card-number-token" name="xCardNum" type="hidden">
                     </div>
@@ -83,7 +83,7 @@
                     </label>
                     <div class="control _with-tooltip">
                         <iframe data-ifields-id="cvv" data-ifields-placeholder="CVV"
-                        src="https://cdn.cardknox.com/ifields/3.1.2508.1401/ifield.htm" frameBorder="0"
+                        src="https://cdn.cardknox.com/ifields/3.3.2601.2901/ifield.htm" frameBorder="0"
                         height="35"></iframe>
                         <div class="field-tooltip toggle">
                             <span class="field-tooltip-action action-cvv"

--- a/view/frontend/web/template/payment/cardknox-google-pay-method.html
+++ b/view/frontend/web/template/payment/cardknox-google-pay-method.html
@@ -44,7 +44,7 @@
             <div class="primary">
                 <div class="gpay-content">
                     <div id="divGpay" class="gp hidden">
-                        <iframe id="igp" class="gp" data-ifields-id="igp" afterRender="initFrame()" src="https://cdn.cardknox.com/ifields/3.1.2508.1401/igp.htm"
+                        <iframe id="igp" class="gp" data-ifields-id="igp" afterRender="initFrame()" src="https://cdn.cardknox.com/ifields/3.3.2601.2901/igp.htm"
                                 allowpaymentrequest
                                 sandbox="allow-popups allow-modals allow-scripts allow-same-origin allow-forms allow-popups-to-escape-sandbox allow-top-navigation"
                                 title="GPay checkout page">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Cardknox iFields to version 3.3.2601.2901 and adjust CSP whitelist accordingly.
> 
>   - **Version Update**:
>     - Update Cardknox iFields version to `3.3.2601.2901` in `cc.phtml`, `cardknox-form.html`, `google-pay-btn.html`, and `cardknox-google-pay-method.html`.
>     - Update `requirejs-config.js` to use new iFields version.
>   - **CSP Whitelist**:
>     - Update `csp_whitelist.xml` to include new script and iframe sources for Cardknox iFields and 3DS SDK.
>     - Add `*.cardinaltrusted.com` to `script-src`, `frame-src`, `connect-src`, and `form-action` policies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cardknox%2Fmagento2_cardknox&utm_source=github&utm_medium=referral)<sup> for 0d626392f5259eda04cf7059a914165c57e50f8a. You can [customize](https://app.ellipsis.dev/cardknox/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->