### PR TITLE
PLGN-223 Add Level 3 Field Mapping Support to Magento Plugin

### DIFF
--- a/.github/workflows/run-magento-tests.yml
+++ b/.github/workflows/run-magento-tests.yml
@@ -56,6 +56,14 @@ jobs:
         # Install Magento2 Coding Standard for PHPCS
         composer require --dev magento/magento-coding-standard --no-interaction
 
+    - name: Install MSI (Multi-Source Inventory) Modules
+      run: |
+        wget https://github.com/magento/inventory/archive/refs/tags/1.2.8-p4.tar.gz -O inventory.tar.gz
+        tar -xzf inventory.tar.gz
+        mkdir -p magento/app/code/Magento
+        cp -r inventory-1.2.8-p4/Inventory* magento/app/code/Magento/
+        rm -rf inventory.tar.gz inventory-1.2.8-p4
+
     - name: Create Directories for Cardknox Module
       run: |
         mkdir -p magento/app/code/CardknoxDevelopment

--- a/.github/workflows/run-magento-tests.yml
+++ b/.github/workflows/run-magento-tests.yml
@@ -58,7 +58,10 @@ jobs:
 
     - name: Install MSI (Multi-Source Inventory) Modules
       run: |
+        set -e
+        EXPECTED_SHA="13e28a00337e6918d1b1653258540c148e1557dfa6b801534f0b4976b3535215f7b28ef6131f7d333272eb5061df68f7279bb7c53457662a77b7158f15315898"
         wget https://github.com/magento/inventory/archive/refs/tags/1.2.8-p4.tar.gz -O inventory.tar.gz
+        echo "$EXPECTED_SHA  inventory.tar.gz" | sha512sum -c -
         tar -xzf inventory.tar.gz
         mkdir -p magento/app/code/Magento
         cp -r inventory-1.2.8-p4/Inventory* magento/app/code/Magento/

--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -24,6 +24,7 @@ class Config extends \Magento\Payment\Gateway\Config\Config
     public const CARDKNOX_ENABLE_THREE_D_SECURE = "cardknox_enable_three_d_secure";
     public const CARDKNOX_THREE_D_SECURE_ENVIRONMENT = "cardknox_three_d_secure_environment";
     public const CARDKNOX_THREE_D_SECURE_VERIFY_URL = "three_ds_verify_url";
+    public const LEVEL3_ENABLED = "level3_enabled";
     /**
      * IsActive function
      *
@@ -177,5 +178,15 @@ class Config extends \Magento\Payment\Gateway\Config\Config
     public function getThreeDSVerifyUrl()
     {
         return $this->getValue(self::CARDKNOX_THREE_D_SECURE_VERIFY_URL);
+    }
+
+    /**
+     * Check if Level 3 data is enabled
+     *
+     * @return bool
+     */
+    public function isLevel3Enabled(): bool
+    {
+        return (bool) $this->getValue(self::LEVEL3_ENABLED);
     }
 }

--- a/Gateway/Request/DataRequest.php
+++ b/Gateway/Request/DataRequest.php
@@ -113,16 +113,34 @@ class DataRequest implements BuilderInterface
             return [];
         }
 
+        $payment = $paymentDO->getPayment();
         /** @var \Magento\Sales\Model\Order $salesOrder */
-        $salesOrder = $paymentDO->getPayment()->getOrder();
+        $salesOrder = $payment->getOrder();
 
-        // Order-level fields
-        $result = [
-            'xPONum'      => $salesOrder->getIncrementId(),
-            'xTax'        => $this->helper->formatPrice($salesOrder->getTaxAmount()),
-            'xDiscount'   => $this->helper->formatPrice(abs((float) $salesOrder->getDiscountAmount())),
-            'xShipAmount' => $this->helper->formatPrice($salesOrder->getShippingAmount()),
-        ];
+        // Check if this is a capture (split capture / regular capture)
+        $isCapture = ($payment->getLastTransId() != '');
+        $invoice = null;
+
+        if ($isCapture) {
+            $invoice = $this->getCurrentInvoice($salesOrder);
+        }
+
+        // Order-level fields — use invoice totals for capture, order totals for auth/sale
+        if ($invoice) {
+            $result = [
+                'xPONum'      => $salesOrder->getIncrementId(),
+                'xTax'        => $this->helper->formatPrice($invoice->getTaxAmount()),
+                'xDiscount'   => $this->helper->formatPrice(abs((float) $invoice->getDiscountAmount())),
+                'xShipAmount' => $this->helper->formatPrice($invoice->getShippingAmount()),
+            ];
+        } else {
+            $result = [
+                'xPONum'      => $salesOrder->getIncrementId(),
+                'xTax'        => $this->helper->formatPrice($salesOrder->getTaxAmount()),
+                'xDiscount'   => $this->helper->formatPrice(abs((float) $salesOrder->getDiscountAmount())),
+                'xShipAmount' => $this->helper->formatPrice($salesOrder->getShippingAmount()),
+            ];
+        }
 
         // Ship-from ZIP — only when MSI is NOT enabled
         if (!$this->helper->isMsiEnabled()) {
@@ -133,10 +151,69 @@ class DataRequest implements BuilderInterface
         }
 
         // Line-item fields
-        $items = $salesOrder->getAllItems();
+        if ($invoice) {
+            $this->addInvoiceLineItems($result, $invoice);
+        } else {
+            $this->addOrderLineItems($result, $salesOrder);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Add line items from invoice (for capture/split capture)
+     * Only includes items with qty > 0 in the invoice
+     *
+     * @param array &$result
+     * @param \Magento\Sales\Model\Order\Invoice $invoice
+     * @return void
+     */
+    private function addInvoiceLineItems(array &$result, $invoice): void
+    {
         $index = 1;
 
-        foreach ($items as $item) {
+        foreach ($invoice->getAllItems() as $invoiceItem) {
+            $qty = (int) $invoiceItem->getQty();
+
+            // Skip items not being invoiced
+            if ($qty <= 0) {
+                continue;
+            }
+
+            $orderItem = $invoiceItem->getOrderItem();
+
+            // Skip parent items — only pass child items
+            if ($orderItem->getChildrenItems()) {
+                continue;
+            }
+
+            // For child items with price=0, get price from parent
+            $price = $orderItem->getPrice();
+            if ($price == 0 && $orderItem->getParentItem()) {
+                $price = $orderItem->getParentItem()->getPrice();
+            }
+
+            $result['x' . $index . 'Sku']         = (string) $invoiceItem->getSku();
+            $result['x' . $index . 'Description'] = (string) $invoiceItem->getName();
+            $result['x' . $index . 'Qty']         = (string) $qty;
+            $result['x' . $index . 'UnitPrice']   = $this->helper->formatPrice($price);
+
+            $index++;
+        }
+    }
+
+    /**
+     * Add line items from order (for authorize/sale)
+     *
+     * @param array &$result
+     * @param \Magento\Sales\Model\Order $salesOrder
+     * @return void
+     */
+    private function addOrderLineItems(array &$result, $salesOrder): void
+    {
+        $index = 1;
+
+        foreach ($salesOrder->getAllItems() as $item) {
             // Skip parent items — only pass child items
             if ($item->getChildrenItems()) {
                 continue;
@@ -157,7 +234,25 @@ class DataRequest implements BuilderInterface
 
             $index++;
         }
+    }
 
-        return $result;
+    /**
+     * Get the current invoice being captured
+     * Returns the latest unpaid invoice from the order
+     *
+     * @param \Magento\Sales\Model\Order $salesOrder
+     * @return \Magento\Sales\Model\Order\Invoice|null
+     */
+    private function getCurrentInvoice($salesOrder)
+    {
+        $invoice = null;
+        foreach ($salesOrder->getInvoiceCollection() as $inv) {
+            if ($inv->getState() == \Magento\Sales\Model\Order\Invoice::STATE_OPEN
+                || !$inv->getEntityId()
+            ) {
+                $invoice = $inv;
+            }
+        }
+        return $invoice;
     }
 }

--- a/Gateway/Request/DataRequest.php
+++ b/Gateway/Request/DataRequest.php
@@ -152,24 +152,25 @@ class DataRequest implements BuilderInterface
 
         // Line-item fields
         if ($invoice) {
-            $this->addInvoiceLineItems($result, $invoice);
+            $lineItems = $this->getInvoiceLineItems($invoice);
         } else {
-            $this->addOrderLineItems($result, $salesOrder);
+            $lineItems = $this->getOrderLineItems($salesOrder);
         }
 
-        return $result;
+        return array_merge($result, $lineItems);
     }
 
     /**
-     * Add line items from invoice (for capture/split capture)
+     * Get line items from invoice (for capture/split capture)
+     *
      * Only includes items with qty > 0 in the invoice
      *
-     * @param array &$result
      * @param \Magento\Sales\Model\Order\Invoice $invoice
-     * @return void
+     * @return array
      */
-    private function addInvoiceLineItems(array &$result, $invoice): void
+    private function getInvoiceLineItems($invoice): array
     {
+        $lineItems = [];
         $index = 1;
 
         foreach ($invoice->getAllItems() as $invoiceItem) {
@@ -193,24 +194,26 @@ class DataRequest implements BuilderInterface
                 $price = $orderItem->getParentItem()->getPrice();
             }
 
-            $result['x' . $index . 'Sku']         = (string) $invoiceItem->getSku();
-            $result['x' . $index . 'Description'] = (string) $invoiceItem->getName();
-            $result['x' . $index . 'Qty']         = (string) $qty;
-            $result['x' . $index . 'UnitPrice']   = $this->helper->formatPrice($price);
+            $lineItems['x' . $index . 'Sku']         = (string) $invoiceItem->getSku();
+            $lineItems['x' . $index . 'Description'] = (string) $invoiceItem->getName();
+            $lineItems['x' . $index . 'Qty']         = (string) $qty;
+            $lineItems['x' . $index . 'UnitPrice']   = $this->helper->formatPrice($price);
 
             $index++;
         }
+
+        return $lineItems;
     }
 
     /**
-     * Add line items from order (for authorize/sale)
+     * Get line items from order (for authorize/sale)
      *
-     * @param array &$result
      * @param \Magento\Sales\Model\Order $salesOrder
-     * @return void
+     * @return array
      */
-    private function addOrderLineItems(array &$result, $salesOrder): void
+    private function getOrderLineItems($salesOrder): array
     {
+        $lineItems = [];
         $index = 1;
 
         foreach ($salesOrder->getAllItems() as $item) {
@@ -227,20 +230,23 @@ class DataRequest implements BuilderInterface
                 $price = $item->getParentItem()->getPrice();
             }
 
-            $result['x' . $index . 'Sku']         = (string) $item->getSku();
-            $result['x' . $index . 'Description'] = (string) $item->getName();
-            $result['x' . $index . 'Qty']         = (string) $qty;
-            $result['x' . $index . 'UnitPrice']   = $this->helper->formatPrice($price);
+            $lineItems['x' . $index . 'Sku']         = (string) $item->getSku();
+            $lineItems['x' . $index . 'Description'] = (string) $item->getName();
+            $lineItems['x' . $index . 'Qty']         = (string) $qty;
+            $lineItems['x' . $index . 'UnitPrice']   = $this->helper->formatPrice($price);
 
             $index++;
         }
+
+        return $lineItems;
     }
 
     /**
      * Get the current invoice being captured
+     *
      * Returns the latest unpaid invoice from the order
      *
-     * @param \Magento\Sales\Model\Order $salesOrder
+     * @param  \Magento\Sales\Model\Order $salesOrder
      * @return \Magento\Sales\Model\Order\Invoice|null
      */
     private function getCurrentInvoice($salesOrder)

--- a/Gateway/Request/DataRequest.php
+++ b/Gateway/Request/DataRequest.php
@@ -183,16 +183,12 @@ class DataRequest implements BuilderInterface
 
             $orderItem = $invoiceItem->getOrderItem();
 
-            // Skip parent items — only pass child items
-            if ($orderItem->getChildrenItems()) {
+            // Skip child items — parent holds the correct price
+            if ($orderItem->getParentItem()) {
                 continue;
             }
 
-            // For child items with price=0, get price from parent
             $price = $orderItem->getPrice();
-            if ($price == 0 && $orderItem->getParentItem()) {
-                $price = $orderItem->getParentItem()->getPrice();
-            }
 
             $lineItems['x' . $index . 'Sku']         = (string) $invoiceItem->getSku();
             $lineItems['x' . $index . 'Description'] = (string) $invoiceItem->getName();
@@ -217,18 +213,13 @@ class DataRequest implements BuilderInterface
         $index = 1;
 
         foreach ($salesOrder->getAllItems() as $item) {
-            // Skip parent items — only pass child items
-            if ($item->getChildrenItems()) {
+            // Skip child items — parent holds the correct price
+            if ($item->getParentItem()) {
                 continue;
             }
 
             $qty = (int) $item->getQtyOrdered();
-
-            // For child items with price=0, get price from parent
             $price = $item->getPrice();
-            if ($price == 0 && $item->getParentItem()) {
-                $price = $item->getParentItem()->getPrice();
-            }
 
             $lineItems['x' . $index . 'Sku']         = (string) $item->getSku();
             $lineItems['x' . $index . 'Description'] = (string) $item->getName();

--- a/Gateway/Request/DataRequest.php
+++ b/Gateway/Request/DataRequest.php
@@ -7,12 +7,38 @@ namespace CardknoxDevelopment\Cardknox\Gateway\Request;
 
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Gateway\Request\BuilderInterface;
+use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
+use CardknoxDevelopment\Cardknox\Helper\Data;
 
 class DataRequest implements BuilderInterface
 {
     public const AMOUNT = 'xAmount';
     public const INVOICE = 'xInvoice';
     public const CARDNUM = 'xCardNum';
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var Data
+     */
+    private $helper;
+
+    /**
+     * Constructor
+     *
+     * @param Config $config
+     * @param Data $helper
+     */
+    public function __construct(
+        Config $config,
+        Data $helper
+    ) {
+        $this->config = $config;
+        $this->helper = $helper;
+    }
 
     /**
      * Builds ENV request
@@ -35,9 +61,12 @@ class DataRequest implements BuilderInterface
         $order = $paymentDO->getOrder();
         $billing = $order->getBillingAddress();
         $shipping = $order->getShippingAddress();
+
+        $level3Data = $this->getLevel3Data($paymentDO);
+
         //its a reguler capture
         if ($payment->getLastTransId() != '') {
-            return [];
+            return $level3Data;
         }
         //its a authorize and capture
         $result = [
@@ -69,6 +98,66 @@ class DataRequest implements BuilderInterface
             $result2 = [];
         }
 
-        return array_merge_recursive($result, $result2);
+        return array_merge_recursive($result, $result2, $level3Data);
+    }
+
+    /**
+     * Get Level 3 data (order-level and line-item fields)
+     *
+     * @param PaymentDataObjectInterface $paymentDO
+     * @return array
+     */
+    private function getLevel3Data(PaymentDataObjectInterface $paymentDO): array
+    {
+        if (!$this->config->isLevel3Enabled()) {
+            return [];
+        }
+
+        /** @var \Magento\Sales\Model\Order $salesOrder */
+        $salesOrder = $paymentDO->getPayment()->getOrder();
+
+        // Order-level fields
+        $result = [
+            'xPONum'      => $salesOrder->getIncrementId(),
+            'xTax'        => $this->helper->formatPrice($salesOrder->getTaxAmount()),
+            'xDiscount'   => $this->helper->formatPrice(abs((float) $salesOrder->getDiscountAmount())),
+            'xShipAmount' => $this->helper->formatPrice($salesOrder->getShippingAmount()),
+        ];
+
+        // Ship-from ZIP — only when MSI is NOT enabled
+        if (!$this->helper->isMsiEnabled()) {
+            $shipFromZip = $this->helper->getShippingOriginZip();
+            if ($shipFromZip) {
+                $result['xShipFromZip'] = $shipFromZip;
+            }
+        }
+
+        // Line-item fields
+        $items = $salesOrder->getAllItems();
+        $index = 1;
+
+        foreach ($items as $item) {
+            // Skip parent items — only pass child items
+            if ($item->getChildrenItems()) {
+                continue;
+            }
+
+            $qty = (int) $item->getQtyOrdered();
+
+            // For child items with price=0, get price from parent
+            $price = $item->getPrice();
+            if ($price == 0 && $item->getParentItem()) {
+                $price = $item->getParentItem()->getPrice();
+            }
+
+            $result['x' . $index . 'Sku']         = (string) $item->getSku();
+            $result['x' . $index . 'Description'] = (string) $item->getName();
+            $result['x' . $index . 'Qty']         = (string) $qty;
+            $result['x' . $index . 'UnitPrice']   = $this->helper->formatPrice($price);
+
+            $index++;
+        }
+
+        return $result;
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -4,6 +4,7 @@ namespace CardknoxDevelopment\Cardknox\Helper;
 
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
+use Magento\InventoryCatalogApi\Model\IsSingleSourceModeInterface;
 
 class Data extends AbstractHelper
 {
@@ -18,15 +19,23 @@ class Data extends AbstractHelper
     private $remoteAddress;
 
     /**
+     * @var IsSingleSourceModeInterface
+     */
+    private $isSingleSourceMode;
+
+    /**
      * @param \Magento\Framework\App\Helper\Context $context
      * @param RemoteAddress $remoteAddress
+     * @param IsSingleSourceModeInterface $isSingleSourceMode
      * phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
-        RemoteAddress $remoteAddress
+        RemoteAddress $remoteAddress,
+        IsSingleSourceModeInterface $isSingleSourceMode
     ) {
         $this->remoteAddress = $remoteAddress;
+        $this->isSingleSourceMode = $isSingleSourceMode;
         parent::__construct($context);
     }
 
@@ -115,6 +124,33 @@ class Data extends AbstractHelper
         return $this->scopeConfig->getValue(
             $key,
             $storeId
+        );
+    }
+
+    /**
+     * Check if Magento MSI (Multi-Source Inventory) is actively used
+     *
+     * Uses IsSingleSourceModeInterface which queries the inventory_source table.
+     * - 0 or 1 enabled source → single-source mode → returns false (MSI not active)
+     * - 2+ enabled sources → multi-source mode → returns true (MSI active)
+     *
+     * @return bool
+     */
+    public function isMsiEnabled(): bool
+    {
+        return !$this->isSingleSourceMode->execute();
+    }
+
+    /**
+     * Get shipping origin ZIP/Postal Code from store config
+     *
+     * @return string|null
+     */
+    public function getShippingOriginZip(): ?string
+    {
+        return $this->scopeConfig->getValue(
+            'shipping/origin/postcode',
+            \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE
         );
     }
 }

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
+use Magento\InventoryCatalogApi\Model\IsSingleSourceModeInterface;
 
 class DataTest extends TestCase
 {
@@ -50,6 +51,11 @@ class DataTest extends TestCase
     private $remoteAddress;
 
     /**
+     * @var IsSingleSourceModeInterface&MockObject
+     */
+    private $isSingleSourceMode;
+
+    /**
      * @return void
      */
     protected function setUp(): void
@@ -74,13 +80,17 @@ class DataTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->isSingleSourceMode = $this->getMockBuilder(IsSingleSourceModeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->_outputConfig = $this->getMockForAbstractClass(ConfigInterface::class);
 
         $this->contextMock->expects($this->any())
             ->method('getScopeConfig')
             ->willReturn($this->scopeConfig);
 
-        $this->helper = new Data($this->contextMock, $this->remoteAddress);
+        $this->helper = new Data($this->contextMock, $this->remoteAddress, $this->isSingleSourceMode);
     }
 
     public function testFormatPrice()

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -44,6 +44,14 @@
                     <label>Payment Action</label>
                     <source_model>CardknoxDevelopment\Cardknox\Model\Adminhtml\Source\PaymentAction</source_model>
                 </field>
+                <field id="level3_enabled" translate="label comment" type="select" sortOrder="114" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Enable Level 3 Data</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[When enabled, sends order-level and line-item Level 3 fields to the gateway.]]></comment>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
                 <field id="cardknox_cc_split_capture_enabled" translate="label" type="select" sortOrder="111" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Enable Split Capture For Credit Card</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -49,6 +49,7 @@
                 <allowspecific>0</allowspecific>
                 <ck_giftcard_enabled>0</ck_giftcard_enabled>
                 <ck_giftcard_text>Sola Gift Card</ck_giftcard_text>
+                <level3_enabled>0</level3_enabled>
             </cardknox>
             <cardknox_cc_vault>
                 <model>CardknoxCreditCardVaultFacade</model>


### PR DESCRIPTION
### Summary                                                                   
- Adds Level 3 (line-item) data support for the Cardknox payment gateway. 
- When enabled, the integration sends order-level and per-line-item fields to  Cardknox on `Authorize`, `Capture`, and `Split Capture` transactions across all payment methods (**CC, Vault, Google Pay, Apple Pay**).                           
                                                     
### Changes
  - **Admin config toggle:** New `Enable Level 3 Data` setting under `Stores →
  Configuration → Sales → Payment Methods → Cardknox` (default: **disabled**).  
  Existing behaviour is unchanged when the toggle is off.
  - **Order-level fields:** `xPONum`, `xTax`, `xDiscount`, `xShipAmount` sent on Auth/Capture.                                                                
  - **Line-item fields:** `x{n}Sku`, `x{n}Description`, `x{n}Qty`, `x{n}UnitPrice` sent per item.                                                
  - **Ship-from ZIP:** `xShipFromZip` populated from Magento's shipping origin config when MSI is **not** active (single-source mode only).
  - **Parent/child item handling:** For configurable and bundle products, sends **parent items** (skipping child items) per Magento standard, since child  items don't carry the correct price — the parent holds the accurate price.
  - **Split capture / partial invoice:** Line items are sourced from the invoice (qty > 0 only) so partial captures send the correct line set and totals.
  - **Scope:** Level 3 data is only sent on Authorize and Capture commands.
  Void, Refund, and Cancel are intentionally excluded via DI wiring.
  - **CI/CD:** Updated GitHub Actions workflow to install MSI modules so the `di:compile` step covers both MSI and non-MSI code paths. 
                                                     
### Implementation Notes
  - `xPONum` uses `$salesOrder->getIncrementId()` because at authorize time the order is not yet persisted to the DB, so `getEntityId()` / `getId()` return  `NULL`. `increment_id` is reliably populated across both Auth and Capture and is the human-readable order number merchants/customers recognize.             
  - Line totals are validated to equal the transaction amount to satisfy Cardknox's Level 3 validation.
  - MSI modules added to the `di:compile` GitHub Action workflow so the build covers MSI/non-MSI code paths.                                                
  - PHPCS coding standard warnings in `DataRequest.php` resolved.