### PR TITLE
PLGN-227 Fix failing PHP Unit tests (PHPUnit 12) after Magento 2.4.9 upgrade 

### DIFF
--- a/.github/workflows/run-magento-tests.yml
+++ b/.github/workflows/run-magento-tests.yml
@@ -38,16 +38,16 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.4'
+        php-version: '8.5'
         extensions: mbstring, intl, gd, xml, soap, zip, bcmath, opcache, pdo_mysql, curl, dom, hash, iconv, json, simplexml, xsl, xmlreader, xmlwriter, session
         tools: composer:v2
 
     - name: Download Magento Directly
       run: |
-        # Download Magento 2.4.8-p3 from GitHub
-        wget https://github.com/magento/magento2/archive/2.4.8-p3.zip
-        unzip 2.4.8-p3.zip
-        mv magento2-2.4.8-p3 magento
+        # Download Magento 2.4.9 from GitHub
+        wget https://github.com/magento/magento2/archive/2.4.9.zip
+        unzip 2.4.9.zip
+        mv magento2-2.4.9 magento
 
     - name: Install Dependencies
       run: |
@@ -59,13 +59,13 @@ jobs:
     - name: Install MSI (Multi-Source Inventory) Modules
       run: |
         set -e
-        EXPECTED_SHA="13e28a00337e6918d1b1653258540c148e1557dfa6b801534f0b4976b3535215f7b28ef6131f7d333272eb5061df68f7279bb7c53457662a77b7158f15315898"
-        wget https://github.com/magento/inventory/archive/refs/tags/1.2.8-p4.tar.gz -O inventory.tar.gz
+        EXPECTED_SHA="b121d7ce6067ca297e313c1b71981275cb01bd0c6f8a3e9fc00250d8b9354a46dccafd500a15c5246d2f60194392a2f7e9c6f8786fec59762e3d44a12601a1af"
+        wget https://github.com/magento/inventory/archive/refs/tags/1.2.9.tar.gz -O inventory.tar.gz
         echo "$EXPECTED_SHA  inventory.tar.gz" | sha512sum -c -
         tar -xzf inventory.tar.gz
         mkdir -p magento/app/code/Magento
-        cp -r inventory-1.2.8-p4/Inventory* magento/app/code/Magento/
-        rm -rf inventory.tar.gz inventory-1.2.8-p4
+        cp -r inventory-1.2.9/Inventory* magento/app/code/Magento/
+        rm -rf inventory.tar.gz inventory-1.2.9
 
     - name: Create Directories for Cardknox Module
       run: |

--- a/.github/workflows/run-magento-tests.yml
+++ b/.github/workflows/run-magento-tests.yml
@@ -77,10 +77,14 @@ jobs:
 
     - name: Enable Cardknox module
       run: |
-        sudo php magento/bin/magento module:enable CardknoxDevelopment_Cardknox --clear-static-content
+        # Enable all modules so DI compilation has access to every class
+        # referenced by core preferences (e.g. Magento_Store ships the
+        # PathInfoProcessor preference; with only Cardknox enabled, 2.4.9's
+        # stricter compiler errors out on the missing dependency).
+        sudo php magento/bin/magento module:enable --all --clear-static-content
         sudo php magento/bin/magento setup:di:compile
         sudo chmod -R 777 magento/generated/ magento/var/ magento/pub/
-        sudo php magento/bin/magento module:status
+        sudo php magento/bin/magento module:status CardknoxDevelopment_Cardknox
 
     - name: Run Unit Tests
       run: |

--- a/.github/workflows/run-magento-tests.yml
+++ b/.github/workflows/run-magento-tests.yml
@@ -77,10 +77,6 @@ jobs:
 
     - name: Enable Cardknox module
       run: |
-        # Enable all modules so DI compilation has access to every class
-        # referenced by core preferences (e.g. Magento_Store ships the
-        # PathInfoProcessor preference; with only Cardknox enabled, 2.4.9's
-        # stricter compiler errors out on the missing dependency).
         sudo php magento/bin/magento module:enable --all --clear-static-content
         sudo php magento/bin/magento setup:di:compile
         sudo chmod -R 777 magento/generated/ magento/var/ magento/pub/

--- a/Test/Unit/Gateway/Http/TransferFactoryTest.php
+++ b/Test/Unit/Gateway/Http/TransferFactoryTest.php
@@ -9,7 +9,9 @@ use CardknoxDevelopment\Cardknox\Gateway\Http\TransferFactory;
 use Magento\Payment\Gateway\Http\TransferBuilder;
 use Magento\Payment\Gateway\Http\TransferInterface;
 use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 class TransferFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Test/Unit/Gateway/Request/AuthorizeRequestTest.php
+++ b/Test/Unit/Gateway/Request/AuthorizeRequestTest.php
@@ -12,7 +12,9 @@ use Magento\Sales\Model\Order\Payment;
 use CardknoxDevelopment\Cardknox\Observer\DataAssignObserver;
 use CardknoxDevelopment\Cardknox\Helper\Data;
 use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 class AuthorizeRequestTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Test/Unit/Gateway/Request/CaptureRequestTest.php
+++ b/Test/Unit/Gateway/Request/CaptureRequestTest.php
@@ -14,7 +14,9 @@ use Magento\Sales\Model\Order\Payment;
 use CardknoxDevelopment\Cardknox\Helper\Data;
 use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 class CaptureRequestTest extends \PHPUnit\Framework\TestCase
 {
     public const XCARDNUM = '4sdfssdfsdfdsf1111';

--- a/Test/Unit/Gateway/Request/RefundRequestTest.php
+++ b/Test/Unit/Gateway/Request/RefundRequestTest.php
@@ -12,7 +12,9 @@ use Magento\Payment\Gateway\Request\BuilderInterface;
 use Magento\Payment\Model\Method\Logger;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Model\Order\Payment;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 class RefundRequestTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Test/Unit/Gateway/Request/VoidRequestTest.php
+++ b/Test/Unit/Gateway/Request/VoidRequestTest.php
@@ -10,7 +10,9 @@ use Magento\Payment\Gateway\ConfigInterface;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Sales\Model\Order\Payment;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 class VoidRequestTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Test/Unit/Gateway/Response/TxnIdHandlerTest.php
+++ b/Test/Unit/Gateway/Response/TxnIdHandlerTest.php
@@ -14,8 +14,10 @@ use Magento\Sales\Model\Order\Payment;
 use Magento\Vault\Model\CreditCardTokenFactory;
 use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[AllowMockObjectsWithoutExpectations]
 class TxnIdHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Test/Unit/Gateway/Validator/ResponseCodeValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/ResponseCodeValidatorTest.php
@@ -10,6 +10,7 @@ use Magento\Payment\Gateway\Validator\ResultInterface;
 use Magento\Payment\Gateway\Validator\ResultInterfaceFactory;
 use Magento\Payment\Model\Method\Logger;
 use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ResponseCodeValidatorTest extends \PHPUnit\Framework\TestCase
@@ -64,9 +65,8 @@ class ResponseCodeValidatorTest extends \PHPUnit\Framework\TestCase
     /**
      * @param array $response
      * @param array $expectationToResultCreation
-     *
-     * @dataProvider validateDataProvider
      */
+    #[DataProvider('validateDataProvider')]
     public function testValidate(array $response, array $expectationToResultCreation)
     {
         $this->resultFactory->expects($this->once())

--- a/Test/Unit/Gateway/Validator/ResponseCodeValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/ResponseCodeValidatorTest.php
@@ -10,9 +10,11 @@ use Magento\Payment\Gateway\Validator\ResultInterface;
 use Magento\Payment\Gateway\Validator\ResultInterfaceFactory;
 use Magento\Payment\Model\Method\Logger;
 use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[AllowMockObjectsWithoutExpectations]
 class ResponseCodeValidatorTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -61,30 +61,20 @@ class DataTest extends TestCase
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
-        $this->scopeInterfaceMock = $this->getMockBuilder(ScopeInterface::class)
-            ->addMethods(['getValue'])
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $this->scopeInterfaceMock = $this->createMock(ScopeInterface::class);
 
         $this->contextMock = $this->getMockBuilder(Context::class)
             ->onlyMethods(['getScopeConfig'])
-            ->addMethods(['getValue'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->scopeConfig = $this->getMockBuilder(ScopeConfigInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
 
-        $this->remoteAddress = $this->getMockBuilder(RemoteAddress::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->remoteAddress = $this->createMock(RemoteAddress::class);
 
-        $this->isSingleSourceMode = $this->getMockBuilder(IsSingleSourceModeInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->isSingleSourceMode = $this->createMock(IsSingleSourceModeInterface::class);
 
-        $this->_outputConfig = $this->getMockForAbstractClass(ConfigInterface::class);
+        $this->_outputConfig = $this->createMock(ConfigInterface::class);
 
         $this->contextMock->expects($this->any())
             ->method('getScopeConfig')

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -1,49 +1,23 @@
 <?php
 namespace CardknoxDevelopment\Cardknox\Test\Unit\Helper;
 
-use Magento\Framework\Module\Output\ConfigInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Store\Model\ScopeInterface;
 use CardknoxDevelopment\Cardknox\Helper\Data;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
 use Magento\InventoryCatalogApi\Model\IsSingleSourceModeInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 class DataTest extends TestCase
 {
-    /**
-     * @var ObjectManager
-     */
-    private $objectManager;
-
-    /**
-     * @var ScopeInterface&MockObject
-     */
-    private $scopeInterfaceMock;
-
-    /**
-     * @var Context&MockObject
-     */
-    private $contextMock;
-
     /**
      * @var ScopeConfigInterface&MockObject
      */
     private $scopeConfig;
-
-    /**
-     * @var Data
-     */
-    private $helper;
-
-    /**
-     * @var ConfigInterface
-     */
-    private $_outputConfig;
 
     /**
      * @var RemoteAddress&MockObject
@@ -51,79 +25,50 @@ class DataTest extends TestCase
     private $remoteAddress;
 
     /**
-     * @var IsSingleSourceModeInterface&MockObject
+     * @var Data
      */
-    private $isSingleSourceMode;
+    private $helper;
 
     /**
      * @return void
      */
     protected function setUp(): void
     {
-        $this->objectManager = new ObjectManager($this);
-        $this->scopeInterfaceMock = $this->createMock(ScopeInterface::class);
-
-        $this->contextMock = $this->getMockBuilder(Context::class)
-            ->onlyMethods(['getScopeConfig'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $contextStub = $this->createStub(Context::class);
         $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $contextStub->method('getScopeConfig')->willReturn($this->scopeConfig);
 
         $this->remoteAddress = $this->createMock(RemoteAddress::class);
+        $isSingleSourceModeStub = $this->createStub(IsSingleSourceModeInterface::class);
 
-        $this->isSingleSourceMode = $this->createMock(IsSingleSourceModeInterface::class);
-
-        $this->_outputConfig = $this->createMock(ConfigInterface::class);
-
-        $this->contextMock->expects($this->any())
-            ->method('getScopeConfig')
-            ->willReturn($this->scopeConfig);
-
-        $this->helper = new Data($this->contextMock, $this->remoteAddress, $this->isSingleSourceMode);
+        $this->helper = new Data($contextStub, $this->remoteAddress, $isSingleSourceModeStub);
     }
 
     public function testFormatPrice()
     {
-        $price = 1.00;
-        $result = $this->helper->formatPrice($price);
-        $this->assertEquals('1.00', $result);
-
-        $price = 10.5;
-        $result = $this->helper->formatPrice($price);
-        $this->assertEquals('10.50', $result);
-
-        $price = 0;
-        $result = $this->helper->formatPrice($price);
-        $this->assertEquals('0.00', $result);
+        $this->assertEquals('1.00', $this->helper->formatPrice(1.00));
+        $this->assertEquals('10.50', $this->helper->formatPrice(10.5));
+        $this->assertEquals('0.00', $this->helper->formatPrice(0));
     }
 
     public function testIsCCSplitCaptureEnabled()
     {
         $this->scopeConfig->expects($this->once())
             ->method('getValue')
-            ->with(
-                Data::IS_CC_SPLIT_CAPTURE_ENABLED,
-                ScopeInterface::SCOPE_WEBSITE
-            )
+            ->with(Data::IS_CC_SPLIT_CAPTURE_ENABLED, ScopeInterface::SCOPE_WEBSITE)
             ->willReturn('1');
 
-        $result = $this->helper->isCCSplitCaptureEnabled();
-        $this->assertEquals('1', $result);
+        $this->assertEquals('1', $this->helper->isCCSplitCaptureEnabled());
     }
 
     public function testIsGPaySplitCaptureEnabled()
     {
         $this->scopeConfig->expects($this->once())
             ->method('getValue')
-            ->with(
-                Data::IS_GPAY_SPLIT_CAPTURE_ENABLED,
-                ScopeInterface::SCOPE_WEBSITE
-            )
+            ->with(Data::IS_GPAY_SPLIT_CAPTURE_ENABLED, ScopeInterface::SCOPE_WEBSITE)
             ->willReturn('1');
 
-        $result = $this->helper->isGPaySplitCaptureEnabled();
-        $this->assertEquals('1', $result);
+        $this->assertEquals('1', $this->helper->isGPaySplitCaptureEnabled());
     }
 
     public function testGetIpAddress()
@@ -134,22 +79,17 @@ class DataTest extends TestCase
             ->with(false)
             ->willReturn($ipAddress);
 
-        $result = $this->helper->getIpAddress();
-        $this->assertEquals($ipAddress, $result);
+        $this->assertEquals($ipAddress, $this->helper->getIpAddress());
     }
 
     public function testIsCardknoxGiftcardEnabled()
     {
         $this->scopeConfig->expects($this->once())
             ->method('getValue')
-            ->with(
-                Data::IS_CARDKNOX_GIFTCARD_ENABLED,
-                ScopeInterface::SCOPE_WEBSITE
-            )
+            ->with(Data::IS_CARDKNOX_GIFTCARD_ENABLED, ScopeInterface::SCOPE_WEBSITE)
             ->willReturn('1');
 
-        $result = $this->helper->isCardknoxGiftcardEnabled();
-        $this->assertEquals('1', $result);
+        $this->assertEquals('1', $this->helper->isCardknoxGiftcardEnabled());
     }
 
     public function testCardknoxGiftcardText()
@@ -157,14 +97,10 @@ class DataTest extends TestCase
         $text = 'Test Gift Card Text';
         $this->scopeConfig->expects($this->once())
             ->method('getValue')
-            ->with(
-                Data::IS_CARDKNOX_GIFTCARD_TEXT,
-                ScopeInterface::SCOPE_WEBSITE
-            )
+            ->with(Data::IS_CARDKNOX_GIFTCARD_TEXT, ScopeInterface::SCOPE_WEBSITE)
             ->willReturn($text);
 
-        $result = $this->helper->cardknoxGiftcardText();
-        $this->assertEquals($text, $result);
+        $this->assertEquals($text, $this->helper->cardknoxGiftcardText());
     }
 
     public function testGetConfigValue()
@@ -178,7 +114,6 @@ class DataTest extends TestCase
             ->with($key, $storeId)
             ->willReturn($value);
 
-        $result = $this->helper->getConfigValue($key, $storeId);
-        $this->assertEquals($value, $result);
+        $this->assertEquals($value, $this->helper->getConfigValue($key, $storeId));
     }
 }

--- a/Test/Unit/Model/Methods/GooglePayMethodTest.php
+++ b/Test/Unit/Model/Methods/GooglePayMethodTest.php
@@ -7,9 +7,11 @@ namespace CardknoxDevelopment\Cardknox\Test\Unit\Model\Methods;
 
 use CardknoxDevelopment\Cardknox\Model\Methods\GooglePayMethod;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Magento\Payment\Model\Method\AbstractMethod;
 
+#[AllowMockObjectsWithoutExpectations]
 class GooglePayMethodTest extends TestCase
 {
     /**

--- a/Test/Unit/Model/Ui/ApplePayConfigProviderTest.php
+++ b/Test/Unit/Model/Ui/ApplePayConfigProviderTest.php
@@ -10,9 +10,11 @@ use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
 use CardknoxDevelopment\Cardknox\Model\Ui\ApplePayConfigProvider;
 use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[AllowMockObjectsWithoutExpectations]
 class ApplePayConfigProviderTest extends TestCase
 {
     /**

--- a/Test/Unit/Model/Ui/ApplePayConfigProviderTest.php
+++ b/Test/Unit/Model/Ui/ApplePayConfigProviderTest.php
@@ -55,8 +55,7 @@ class ApplePayConfigProviderTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
             
-        $this->localeResolver = $this->getMockBuilder(ResolverInterface::class)
-            ->getMockForAbstractClass();
+        $this->localeResolver = $this->createMock(ResolverInterface::class);
             
         $this->configProvider = $this->objectManager->getObject(
             ApplePayConfigProvider::class,

--- a/Test/Unit/Model/Ui/ConfigProviderTest.php
+++ b/Test/Unit/Model/Ui/ConfigProviderTest.php
@@ -9,7 +9,9 @@ namespace CardknoxDevelopment\Cardknox\Test\Unit\Model\Ui;
 use CardknoxDevelopment\Cardknox\Model\Ui\ConfigProvider;
 use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
 use Magento\Framework\Locale\ResolverInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 class ConfigProviderTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/Test/Unit/Model/Ui/GooglePayConfigProviderTest.php
+++ b/Test/Unit/Model/Ui/GooglePayConfigProviderTest.php
@@ -11,7 +11,9 @@ use CardknoxDevelopment\Cardknox\Gateway\Config\Config;
 use Magento\Checkout\Model\ConfigProviderInterface;
 use CardknoxDevelopment\Cardknox\Gateway\Config\GpayConfig;
 use Magento\Framework\Locale\ResolverInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 class GooglePayConfigProviderTest extends \PHPUnit\Framework\TestCase
 {
     public const CODE = 'cardknox_google_pay';

--- a/Test/Unit/Model/Ui/TokenUiComponentProviderTest.php
+++ b/Test/Unit/Model/Ui/TokenUiComponentProviderTest.php
@@ -12,9 +12,11 @@ use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Model\Ui\TokenUiComponentInterface;
 use Magento\Vault\Model\Ui\TokenUiComponentInterfaceFactory;
 use Magento\Vault\Model\Ui\TokenUiComponentProviderInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[AllowMockObjectsWithoutExpectations]
 class TokenUiComponentProviderTest extends TestCase
 {
     /**

--- a/Test/Unit/Observer/DataAssignObserverTest.php
+++ b/Test/Unit/Observer/DataAssignObserverTest.php
@@ -11,8 +11,10 @@ use Magento\Payment\Model\InfoInterface;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use CardknoxDevelopment\Cardknox\Observer\DataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[AllowMockObjectsWithoutExpectations]
 class DataAssignObserverTest extends \PHPUnit\Framework\TestCase
 {
     public const XCARDNUM = '4444333322221111';

--- a/Test/Unit/ViewModel/DataTest.php
+++ b/Test/Unit/ViewModel/DataTest.php
@@ -26,7 +26,7 @@ class DataTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->scopeConfig = $this->getMockForAbstractClass(ScopeConfigInterface::class);
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
         $this->viewModel = new Data($this->scopeConfig);
     }
 


### PR DESCRIPTION
# PLGN-227 Make unit tests pass cleanly on PHPUnit 12 with latest Magento v2.4.9

---

## Summary

Magento 2.4.9 ships with **PHPUnit 12**, which (a) removed several legacy
`MockObject` APIs, (b) stopped recognizing the `@dataProvider` docblock
annotation, and (c) introduced a new advisory that fires per-test when a
mock object has no expectations configured against it. In addition,
2.4.9's `setup:di:compile` is stricter about resolving preferences
against actually-enabled modules — the previous CI workflow's
"enable only Cardknox" approach was tolerated by 2.4.8-p3 but errors out
on 2.4.9.

This PR brings the suite to **50 tests, 149 assertions, 0 errors,
0 failures, 0 notices, 0 deprecations** under PHPUnit 12.5.25, updates
the GitHub Actions workflow to build against Magento 2.4.9 on PHP 8.5,
and fixes the resulting DI compile failure.

**Jira:** PLGN-227

## Commits in this PR

1. **`PLGN-227 Upgrade unit tests for PHPUnit 12 and bump CI to Magento 2.4.9`** — fixes the 22 hard errors and updates CI to Magento 2.4.9 / PHP 8.5 / MSI 1.2.9.
2. **`PLGN-227 Eliminate PHPUnit 12 mock-without-expectations notices in unit tests`** — cleans up the remaining 37 advisory notices so CI shows a clean green instead of "OK, but there were issues!".
3. **`PLGN-227 Enable all Magento modules before setup:di:compile in CI`** — fixes a `Reader.php line 122: "PathInfoProcessor … has not been included in dependency injection compilation"` error introduced by 2.4.9's stricter DI compiler.

## Changes

### 1. Unit test fixes (PHPUnit 12 API compatibility)

| File | Change |
|------|--------|
| `Test/Unit/ViewModel/DataTest.php` | Replaced `getMockForAbstractClass()` with `createMock()` — the canonical interface mock factory since PHPUnit 5.4, supported in 10 / 11 / 12. |
| `Test/Unit/Model/Ui/ApplePayConfigProviderTest.php` | Same swap for the `ResolverInterface` mock. |
| `Test/Unit/Helper/DataTest.php` | Dropped `MockBuilder::addMethods()` calls (removed in PHPUnit 12) that added fake `getValue()` methods on mocks never actually invoked anywhere in the test class. Collapsed the remaining mock builders to `createMock()` / `createStub()` for consistency. Deleted four entirely unused mock properties (`scopeInterfaceMock`, `_outputConfig`, `objectManager`, plus stale docblock declarations). |
| `Test/Unit/Gateway/Validator/ResponseCodeValidatorTest.php` | Migrated `testValidate` from the `@dataProvider` docblock annotation to the `#[DataProvider('validateDataProvider')]` attribute (required in PHPUnit 10+). |

### 2. Notice cleanup (mock-without-expectations advisory)

PHPUnit 12 emits a notice per-test whenever a `createMock()` mock has no
expectations configured on it during that test. Because every test class
shares its mocks via `setUp()`, and any given test typically exercises
only a subset of those mocks, the suite was emitting 37 advisory notices
on an otherwise clean run.

| File | Change |
|------|--------|
| `Test/Unit/Helper/DataTest.php` | Switched `Context` and `IsSingleSourceModeInterface` to `createStub()` (pure constructor deps, never have `expects()` or `method()` called on them). Kept `ScopeConfigInterface` and `RemoteAddress` as `createMock()` because individual tests configure them with `->expects()->with()->willReturn()` to verify argument matching. Added `#[AllowMockObjectsWithoutExpectations]` at the class level for the tests that don't exercise every shared mock. |
| All other 13 test files | Added the `use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;` import and the `#[AllowMockObjectsWithoutExpectations]` class-level attribute. |

#### Why the attribute instead of forcing every mock to `createStub()`

Pure switching to `createStub()` would also eliminate the notices, but it
triggers a separate PHPUnit 12 deprecation — *"Using `with*()` on a test
stub has no effect and is deprecated; with PHPUnit 13, it will not be
possible to use `with()` on a test stub"* — and **silently weakens
argument verification** across the suite. The attribute is PHPUnit's
documented opt-out for the legitimate case where mocks are shared via
`setUp()` across tests that exercise different subsets of them. It does
not silence real test failures or mocks that fail to meet their explicit
expectations; it only suppresses the advisory itself. This keeps test
rigor intact and is forward-compatible with PHPUnit 13.

### 3. CI workflow updates (`.github/workflows/run-magento-tests.yml`)

- Bumped PHP from **8.4 → 8.5** (Magento 2.4.9 supports both; matches the local Warden stack).
- Downloads **Magento 2.4.9** instead of 2.4.8-p3.
- Updated MSI bundle from tag **1.2.8-p4 → 1.2.9** — the version pinned by `magento/inventory-metapackage` in 2.4.9 — with a refreshed SHA512 checksum computed from the actual GitHub release tarball.
- **Switched `module:enable CardknoxDevelopment_Cardknox` to `module:enable --all`** so every Magento core module is registered in `app/etc/config.php` before `setup:di:compile` runs. See the next section for the root-cause analysis.

> **Note on MSI:** I initially considered removing the MSI install step under the assumption that 2.4.9 bundles MSI in core. After downloading the 2.4.9 zip to `/tmp` and inspecting it, I confirmed the GitHub source tarball only includes the legacy `CatalogInventory*` modules — MSI is only pulled when installing via the `magento/project-community-edition` composer template. The CI uses the GitHub zip approach, so the MSI step is still required.

### 4. DI compile failure (Reader.php line 122)

After the version bump, CI started failing with:

```
In Reader.php line 122:
  Preference declared for "Magento\Framework\App\Request\PathInfoProcessorInterface"
  as "Magento\Store\App\Request\PathInfoProcessor", but the latter has not been
  included in dependency injection compilation.
```

**Diagnosis:** the workflow's `Enable Cardknox module` step ran
`bin/magento module:enable CardknoxDevelopment_Cardknox` on a fresh
checkout. On fresh installs that command creates `app/etc/config.php`
with **only Cardknox listed**; the ~358 other core modules end up
unregistered (i.e. disabled). The preference for `PathInfoProcessor` is
declared in `vendor/magento/module-store/etc/di.xml`, which the compiler
still scans, but Magento_Store was not enabled so its `PathInfoProcessor`
class wasn't in the compilation pool. Magento 2.4.8-p3 tolerated this;
2.4.9 enforces it strictly and errors out.

Verified that the workflow was green on 2.4.8-p3 (the last ~10 runs were
all `success`) and red on the first 2.4.9 attempts — same workflow
content, only the Magento version differed. `Reader.php` is byte-for-byte
identical between the two releases, so the strictness change is upstream
(in the compiler's class-discovery or preference-resolution path), not in
the error site itself.

**Fix:** `module:enable --all` — registers every discoverable module
before compile, including Magento_Store and Cardknox itself. This mirrors
what a real `setup:install` does and is what Magento's own build
pipelines use. Also narrowed the post-compile `module:status` output to
just `CardknoxDevelopment_Cardknox` to keep the CI log readable instead
of dumping all ~360 module rows.

## Why these changes

PHPUnit 12 dropped:

- `TestCase::getMockForAbstractClass()` and `MockBuilder::getMockForAbstractClass()` — superseded by `createMock()`.
- `MockBuilder::addMethods()` — used to stub methods that don't exist on the target class. PHPUnit 12 only allows mocking real methods.
- The `@dataProvider` docblock annotation — replaced by the `#[DataProvider]` attribute introduced in PHPUnit 10.

And added:

- A per-test advisory notice for any mock that has no expectations set on it in that test.

Magento 2.4.9 also tightened its DI compiler so that previously-tolerated
"enable only one module" CI shortcuts no longer compile cleanly.

Without these fixes the CI build for Magento 2.4.9 cannot pass unit tests
and `setup:di:compile` fails outright.

## Test results

**Before:**
```
ERRORS!
Tests: 48, Assertions: 62, Errors: 22, PHPUnit Notices: 25.
```

**After commit 1 (API fixes):**
```
OK, but there were issues!
Tests: 50, Assertions: 149, PHPUnit Notices: 37.
```

**After commit 2 (notice cleanup):**
```
OK (50 tests, 149 assertions)
```

**After commit 3 (workflow / DI compile fix):**
- CI's `setup:di:compile` step completes successfully on Magento 2.4.9.
- Unit tests run the same suite that's already green locally.

Zero errors, zero failures, zero notices, zero deprecations under
PHPUnit 12.5.25 on Magento 2.4.9 / PHP 8.5.

## Test plan

- [x] `vendor/phpunit/phpunit/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/CardknoxDevelopment/Cardknox/Test/` passes cleanly locally on Magento 2.4.9 / PHP 8.5 / PHPUnit 12.5.25.
- [x] `--display-phpunit-notices --display-phpunit-deprecations` confirms no notices and no deprecations.
- [x] Root-cause analysis of the `Reader.php` DI compile failure documented; fix verified to address the actual mechanism (missing enabled modules in `app/etc/config.php`).
- [x] GitHub Actions workflow `Magento2 Build, PHPUnit Tests & PHP CodeSniffer` runs green on the PR branch end-to-end.
- [x] PHPCS step still passes (no behavioral changes to non-test files).

## Backwards compatibility

- The test-side API replacements (`createMock()`, `createStub()`, `#[DataProvider]`) are all available in PHPUnit 10.0+, so the same tests continue to pass on Magento 2.4.8 / PHPUnit 10.5 as well.
- The `#[AllowMockObjectsWithoutExpectations]` attribute is PHPUnit 12+. On PHPUnit 10/11 it is silently ignored (no notice exists to suppress), so it does not break older runs.
- `module:enable --all` is supported on every Magento 2.x version and is what `setup:install` runs under the hood, so the workflow change is safe for any future version bump.
- No production module code is touched in this PR — changes are limited to test files and the GitHub Actions workflow.
